### PR TITLE
Spacing Group Updates

### DIFF
--- a/src/Spacing/index.js
+++ b/src/Spacing/index.js
@@ -1,5 +1,6 @@
 module.exports = function({ addBase, theme, prefix }) {
   const spacingGroups = theme('spacingGroups', {});
+  const themeCssSpacingProps = theme('spacingGroupProperties', {});
   const cssSpacingProps = {
     m: ['margin'],
     mt: ['margin-top'],
@@ -14,7 +15,18 @@ module.exports = function({ addBase, theme, prefix }) {
     pr: ['padding-right'],
     pl: ['padding-left'],
     px: ['padding-left', 'padding-right'],
-    py: ['padding-top', 'padding-bottom']
+    py: ['padding-top', 'padding-bottom'],
+    gap: ['gap'],
+    'gap-x': ['column-gap'],
+    'gap-y': ['row-gap'],
+    top: ['top'],
+    bottom: ['bottom'],
+    left: ['left'],
+    right: ['right'],
+    inset: ['inset'],
+    'inset-x': ['inset-x'],
+    'inset-y': ['inset-y'],
+    ...themeCssSpacingProps
   };
   const breakpoints = theme('screens');
   const firstBp = Object.keys(breakpoints)[0];


### PR DESCRIPTION
Made some updates to the spacing groups plugin:

Added gap and positioning properties:
```
gap: ['gap'],
'gap-x': ['column-gap'],
'gap-y': ['row-gap'],
top: ['top'],
bottom: ['bottom'],
left: ['left'],
right: ['right'],
inset: ['inset'],
'inset-x': ['inset-x'],
'inset-y': ['inset-y'],
```

Added the ability to add properties to the spacing groups plugin (merges with the properties defined in the plugin, overriding any duplicates):

```
module.exports = {
    ...
    theme: {
        spacingGroupProperties: {
            top: ['top']
        },
    }
    ...
}
```