### PR TITLE
update `ApplyColorVariables` to handle `-` in token names better

### DIFF
--- a/src/ApplyColorVariables/index.js
+++ b/src/ApplyColorVariables/index.js
@@ -9,11 +9,61 @@ module.exports = function (tokens, colors) {
         ? [color.slice(0, colorSplitIndex), color.slice(colorSplitIndex + 1)]
         : [color];
 
-    const found = Object.entries(tokens).find((token) => {
-      const [key, value] = token;
-      return key === color || key === colorSplit[0];
-    });
+    /*
+    Find the matching color token:
 
+    firstly try string match, eg:
+    {
+      "tokens": {
+        "grey-950": "#0D0C0C",
+        "grey-900": "#1B1918",
+        "grey-850": "#282525",
+        "grey-700": "#ADADAD",
+        "grey-100": "#D3D3D3",
+        "green": "#4BB543"
+      }
+    }
+    */
+    let found = Object.entries(tokens).find((token) => token[0] === color);
+
+    if (!found) {
+      /*
+      might be that the token is a group, eg:
+      {
+        "tokens": {
+          "red": {
+            "100": "#D3B2C0",
+            "400": "#EF4637",
+            "500": "#EE3523",
+            "700": "#772848",
+            "800": "#6C002C"
+          }
+        }
+      }
+      */
+      found = Object.entries(tokens).find(
+        (token) => token[0] === colorSplit[0]
+      );
+    }
+
+    /*
+    If nothing found (no matching string, no object of colours),
+    then could be user specified a custom colour, eg:
+    {
+      "background": {
+        "overlay": "rgb(13, 12, 12, 0.7)",
+        "error": "red"
+      }
+    }
+    */
+    if (!found) {
+      // assign custom
+      colors[name] = color;
+    }
+
+    /*
+      something found, assign colour variable:
+    */
     if (found) {
       if (typeof found[1] === 'string') {
         colors[name] = `var(--${found[0]})`;
@@ -26,8 +76,6 @@ module.exports = function (tokens, colors) {
           colors[name] = `var(--${found[0]}-${foundChild})`;
         }
       }
-    } else {
-      colors[name] = color;
     }
   });
 


### PR DESCRIPTION
Can now handle:

```
"color": {
  "tokens": {
    "grey-950": "#0D0C0C",
    "grey-900": "#1B1918",
    "grey-850": "#282525",
    "grey-700": "#ADADAD",
    "grey-100": "#D3D3D3",
    "green": "#4BB543",
    "red": {
      "100": "#D3B2C0",
      "400": "#EF4637",
      "500": "#EE3523",
      "700": "#772848",
      "800": "#6C002C"
    },
    "purple": "#793CB8",
    "purple-light": "rgba(121, 60, 184, 0.1)"
  },
  "text": {
    "text": "grey-700",
    "go": "green",
    "danger": "red-400",
    "tag": "purple",
    "tip": "purple-light",
    "custom": "#00f"
  }
}

```

Previously the `text-tip` would be incorrectly set to `var(--purple)` and not `var(--purple-light)` as the  `ApplyColorVariables` func would find `purple` before  `purple-light`.

This change fixes this.