### PR TITLE
Support string values in spacing groups

### DIFF
--- a/src/Spacing/index.js
+++ b/src/Spacing/index.js
@@ -54,7 +54,9 @@ module.exports = function ({ addBase, theme, prefix }) {
     const [name, spacings] = group;
     Object.entries(spacings).forEach((spacing) => {
       let [bp, space] = spacing;
-      space = parseInt(space, 10) / 16 + 'rem';
+      if (space && typeof space === 'number') {
+        space = parseInt(space, 10) / 16 + 'rem';
+      }
       if (bp === firstBp) {
         rootStyles[':root'][`--spacing-${name}`] = space;
         // create utility class


### PR DESCRIPTION
When working with fluid spacings, we need to be able to use a string that is left untouched by the plugin.

Example:

```json
"spacing-set-1": {
  "sm": 24,
  "md": "clamp(24px, 16.727px + 1.212vw, 40px)"
}
```