### PR TITLE
Support string in spacing values

### DIFF
--- a/src/Spacing/index.js
+++ b/src/Spacing/index.js
@@ -50,7 +50,9 @@ module.exports = function ({ addBase, matchUtilities, theme }) {
     const [name, spacings] = group;
     Object.entries(spacings).forEach((spacing) => {
       let [bp, space] = spacing;
-      space = parseInt(space, 10) / 16 + 'rem';
+      if (space && typeof(space) === 'number') {
+        space = parseInt(space, 10) / 16 + 'rem';
+      }
       if (bp === firstBp) {
         rootStyles[':root'][`--spacing-${name}`] = space;
       } else {


### PR DESCRIPTION
Use case: `clamp()` usage for fluid spacings 