### PR TITLE
Fix the inconsistent HTML code for the container.

### DIFF
--- a/docs/Layout.html
+++ b/docs/Layout.html
@@ -934,7 +934,6 @@ module.exports = {
       class="code-example-code"
     ><code class="language-html">&lt;div class="cols-container">
   &lt;div class="w-cols-1/2">&lt;/div>
-&lt;/div>
   &lt;div class="w-cols-1/4">&lt;/div>
 &lt;/div>
 </code></pre>


### PR DESCRIPTION
# Description

This PR fixes the HTML code that was not closed correctly for the **Containers** section.

<img width="1333" height="253" alt="Capture d’écran 2026-02-10 à 14 53 50" src="https://github.com/user-attachments/assets/2aabe6de-2095-459b-86c6-115915135bfe" />

```diff
<div class="cols-container">
  <div class="w-cols-1/2"></div>
-</div>
  <div class="w-cols-1/4"></div>
</div>
```