### PR TITLE
Add ColorThemes plugin

### DIFF
--- a/docs/ColorThemes.html
+++ b/docs/ColorThemes.html
@@ -17,7 +17,6 @@ title: ColorThemes
 		<li>Background color</li>
 		<li>Border color</li>
 		<li>Outline color</li>
-		<li>Divide color</li>
 		<li>Ring color</li>
 	</ul>
 
@@ -226,6 +225,32 @@ module.exports = {
 		The text will render using the <code>blue-03</code>
 		token when the theme is applied, and fall back to the default <code>text-primary</code>
 		color when it is not.
+	</p>
+
+	<h2 id="theme-reset">Theme Reset</h2>
+
+	<p>
+		The <code>.theme-reset</code>
+		class can be used to revert themed content back to the default token values.
+	</p>
+
+	<p>
+		This is useful when nesting themes and you want a section to ignore an inherited theme and use the base colors instead.
+	</p>
+
+	<figure class="code-example">
+		<figcaption class="code-example-filename">document.html</figcaption>
+		<pre class="code-example-code"><code class="language-html">&lt;div class="theme-accent-1"&gt;
+  &lt;p class="text-primary"&gt;Themed text&lt;/p&gt;
+
+  &lt;div class="theme-reset"&gt;
+    &lt;p class="text-primary"&gt;Default text&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+	</figure>
+
+	<p>
+		The inner content will use the default color values, ignoring the parent theme.
 	</p>
 
 	<h2 id="usage">Usage Guidelines</h2>

--- a/docs/ColorThemes.html
+++ b/docs/ColorThemes.html
@@ -1,0 +1,257 @@
+---
+title: ColorThemes
+---
+{% include_relative includes/_header.html %}
+<div class="copy">
+	<h2 id="description">Description</h2>
+
+	<p>
+		The ColorThemes plugin generates token-based color themes in Tailwind by mapping color values to CSS custom properties. It generates utility classes that resolve to CSS variables with fallback values, allowing colors to be dynamically overridden at runtime via theme classes.
+	</p>
+
+	<h3>Supported Properties</h3>
+
+	<p>The theme system currently supports the following property groups:</p>
+	<ul>
+		<li>Text color</li>
+		<li>Background color</li>
+		<li>Border color</li>
+		<li>Outline color</li>
+		<li>Divide color</li>
+		<li>Ring color</li>
+	</ul>
+
+	<h2 id="how-it-works">How It Works</h2>
+
+	<p>
+		The ColorThemes plugin maps semantic color names (e.g. <code>primary</code>, <code>title</code>) to CSS custom properties.
+	</p>
+
+	<ul>
+		<li>Default values are defined via Tailwind utilities (e.g. <code>text-primary</code>, <code>bg-primary</code>)</li>
+		<li>Theme classes (e.g. <code>.theme-accent-1</code>) override these values using CSS variables</li>
+		<li>Utilities resolve to CSS variables with fallback values</li>
+	</ul>
+
+	<figure class="code-example">
+		<figcaption class="code-example-filename">Generated CSS</figcaption>
+		<pre class="code-example-code"><code class="language-css">.text-primary {
+  color: var(--text-primary, var(--color-grey-90));
+}</code></pre>
+	</figure>
+
+	<p>
+		This allows themes to dynamically override colors at runtime without changing markup. If a theme does not define a value, the fallback token is used.
+	</p>
+
+	<h2 id="setup">Setup</h2>
+
+	<figure class="code-example">
+		<figcaption class="code-example-filename">tailwind.config.js</figcaption>
+		<pre class="code-example-code"><code class="language-javascript">const { ColorTokens, ColorThemes } = require('@area17/a17-tailwind-plugins');
+
+module.exports = {
+  ...
+  plugins: [ColorTokens, ColorThemes],
+  theme: {
+    colors: {
+      "white": "#fff",
+      "grey-3": "#f8f8f8",
+      "grey-5": "#f2f2f2",
+      "grey-10": "#e6e6e6",
+      "grey-15": "#d9d9d9",
+      "grey-30": "#b3b3b3",
+      "grey-54": "#757575",
+      "grey-90": "#1a1a1a",
+      "black": "#000",
+      "blue-01": "#0A152B",
+      "blue-02": "#001F5C",
+      "blue-03": "#004F91",
+      "blue-04": "#313BFB",
+      "blue-05": "#81EEF3",
+      "blue-06": "#ADD8E6",
+      "red-01": "#f00",
+      "green-10": "#F3F7F5",
+      "green-20": "#E6F4EF",
+      "green-30": "#CDE9DE",
+      "green-40": "#9FD8C3",
+      "green-50": "#4CBF99",
+      "green-60": "#158F6A",
+      "green-70": "#1F6F54",
+      "green-90": "#0B3D2E",
+      "purple-10": "#F8F5FC",
+      "purple-20": "#F4EFFB",
+      "purple-30": "#E7DDF7",
+      "purple-40": "#D1C4EE",
+      "purple-50": "#A78BDA",
+      "purple-60": "#7A57B8",
+      "purple-70": "#5B3A8A",
+      "purple-90": "#3A1F5D"
+    },
+    borderColor: ApplyColorVariables(colors, {
+        primary: "grey-5",
+        secondary: "grey-10",
+        tertiary: "grey-15"
+      }
+    ),
+    textColor: ApplyColorVariables(colors, {
+        title: "black",
+        primary: "grey-90",
+        inverse: "white",
+        secondary: "grey-54",
+        accent: "blue-01",
+      }
+    ),
+    backgroundColor: ApplyColorVariables(colors, {
+        primary: "white",
+        secondary: "grey-15",
+        banner: "grey-90",
+        accent: "blue-03",
+        column: "blue-05",
+        column-alt: "blue-04",
+        code: "grey-10",
+        inverse: "black",
+      }
+    ),
+    colorThemes: {
+      "accent-1": {
+        "text": {
+          "title": "green-90",
+          "primary": "green-90",
+          "secondary": "green-70",
+          "accent": "green-60"
+        },
+        "background": {
+          "primary": "green-20",
+          "secondary": "green-30",
+          "inverse": "green-90",
+          "accent": "green-10"
+        },
+        "border": {
+          "primary": "green-50",
+          "secondary": "green-40"
+        }
+      },
+      "accent-2": {
+        "text": {
+          "title": "purple-90",
+          "primary": "purple-90",
+          "secondary": "purple-70",
+          "accent": "purple-60"
+        },
+        "background": {
+          "primary": "purple-20",
+          "secondary": "purple-30",
+          "accent": "purple-10"
+        },
+        "border": {
+          "primary": "purple-50",
+          "secondary": "purple-40"
+        }
+      }
+    },
+  }
+  ...
+};</code></pre>
+	</figure>
+
+	<h2 id="demo">Demo</h2>
+
+	<p>
+		Theme classes are generated based on the keys in the <code>colorThemes</code>
+		config. For example, if we name our theme <code>accent-1</code>, we get a class of <code>.theme-accent-1</code>.
+	</p>
+
+	<div class="flex flex-col gap-gutter md:flex-row mt-inner-2 max-w-full">
+		<div class="lg:w-1/3">
+			<div class="bg-primary border border-primary text-primary p-inner-2">
+				<h3 class="text-title f-h2 mt-0">No theme, default colors</h3>
+				<p class="text-primary mt-12">Lorem ipsum dolor sit amet ut aliquet eros laoreet mi fringilla justo.</p>
+				<sub class="text-accent">In laoreet habitasse lacus orci senectus iaculis magna neque sollicitudin sapien nullam.</sub>
+				<button class="bg-inverse hover:bg-secondary hover:text-title text-inverse block mt-inner-2 py-12 px-24">Button</button>
+			</div>
+		</div>
+		<div class="theme-accent-1 lg:w-1/3">
+			<div class="bg-primary border border-primary text-primary p-inner-2">
+				<h3 class="text-title f-h2 mt-0">With <code class="f-code text-code bg-code px-8 pt-4 pb-2">.theme-accent-1</code>
+					applied</h3>
+				<p class="text-primary mt-12">Lorem ipsum dolor sit amet ut aliquet eros laoreet mi fringilla justo.</p>
+				<sub class="text-accent">In laoreet habitasse lacus orci senectus iaculis magna neque sollicitudin sapien nullam.</sub>
+				<button class="bg-inverse hover:bg-secondary hover:text-title text-inverse block mt-inner-2 py-12 px-24">Button</button>
+			</div>
+		</div>
+		<div class="theme-accent-2 lg:w-1/3">
+			<div class="bg-primary border border-primary text-primary p-inner-2">
+				<h3 class="text-title f-h2 mt-0">With <code class="f-code text-code bg-code px-8 pt-4 pb-2">.theme-accent-2</code>
+					applied</h3>
+				<p class="text-primary mt-12">Lorem ipsum dolor sit amet ut aliquet eros laoreet mi fringilla justo.</p>
+				<sub class="text-accent">In laoreet habitasse lacus orci senectus iaculis magna neque sollicitudin sapien nullam.</sub>
+				<button class="bg-inverse hover:bg-secondary hover:text-title text-inverse block mt-inner-2 py-12 px-24">Button</button>
+			</div>
+		</div>
+	</div>
+
+	<h2 id="minimal-example">Minimal Example</h2>
+
+	<p>
+		A simple theme can be created by mapping semantic keys to color tokens in the <code>colorThemes</code>
+		config.
+	</p>
+
+	<figure class="code-example">
+		<figcaption class="code-example-filename">tailwind.config.js</figcaption>
+		<pre class="code-example-code"><code class="language-javascript">colorThemes: {
+  brand: {
+    text: {
+      primary: "blue-03"
+    }
+  }
+}</code></pre>
+	</figure>
+
+	<p>
+		This generates a theme class <code>.theme-brand</code>
+		that overrides the <code>text-primary</code>
+		utility.
+	</p>
+
+	<figure class="code-example">
+		<figcaption class="code-example-filename">document.html</figcaption>
+		<pre class="code-example-code"><code class="language-html">&lt;div class="theme-brand"&gt;
+  &lt;p class="text-primary"&gt;This text is themed&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+	</figure>
+
+	<p>
+		The text will render using the <code>blue-03</code>
+		token when the theme is applied, and fall back to the default <code>text-primary</code>
+		color when it is not.
+	</p>
+
+	<h2 id="usage">Usage Guidelines</h2>
+
+	<h4>Theme values must reference existing color tokens</h4>
+	<p>Theme color values should reference defined color tokens (e.g. <code>blue-03</code>). Named colors like "blue" will not work unless they exist as tokens.</p>
+
+	<h4>Theme classes must wrap content</h4>
+	<p>The theme class must be applied to a parent element. Utility classes on the same element will not inherit theme values.</p>
+	For example, this will <strong>not</strong>
+	work as expected:
+	<figure class="code-example">
+		<figcaption class="code-example-filename">document.html</figcaption>
+		<pre class="code-example-code"><code class="language-html">&lt;div class="theme-accent-1 bg-primary">&lt;/div></code></pre>
+	</figure>
+	<p>Instead, wrap the element:</p>
+	<figure class="code-example">
+		<figcaption class="code-example-filename">document.html</figcaption>
+		<pre class="code-example-code"><code class="language-html">&lt;div class="theme-accent-1"&gt;
+  &lt;div class="bg-primary"&gt;&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+	</figure>
+
+	<h4>Theme keys must exist in the base token set</h4>
+	<p>All theme keys (e.g. <code>primary</code>, <code>title</code>, etc.) must be defined in the default token set. New keys cannot be introduced in the theme config.
+		This ensures that a valid fallback color is always available.</p>
+</div>
+
+{% include_relative includes/_footer.html %}

--- a/docs/frontend.config.json
+++ b/docs/frontend.config.json
@@ -89,7 +89,23 @@
       "blue-04": "#313BFB",
       "blue-05": "#81EEF3",
       "blue-06": "#ADD8E6",
-      "red-01": "#f00"
+      "red-01": "#f00",
+      "green-10": "#F3F7F5",
+      "green-20": "#E6F4EF",
+      "green-30": "#CDE9DE",
+      "green-40": "#9FD8C3",
+      "green-50": "#4CBF99",
+      "green-60": "#158F6A",
+      "green-70": "#1F6F54",
+      "green-90": "#0B3D2E",
+      "purple-10": "#F8F5FC",
+      "purple-20": "#F4EFFB",
+      "purple-30": "#E7DDF7",
+      "purple-40": "#D1C4EE",
+      "purple-50": "#A78BDA",
+      "purple-60": "#7A57B8",
+      "purple-70": "#5B3A8A",
+      "purple-90": "#3A1F5D"
     },
     "border": {
       "primary": "grey-90",
@@ -120,7 +136,9 @@
       "column-alt": "blue-04",
       "code": "white",
       "code-example": "grey-90",
-      "quote": "grey-5"
+      "quote": "grey-5",
+      "secondary": "grey-15",
+      "inverse": "black"
     },
     "underline": {
       "primary": "grey-54",
@@ -131,7 +149,45 @@
         "primary": "blue-06"
       },
       "thumb": {
-        "primary": "blue-03"
+        "primary": "blue-03",
+        "secondary": "blue-04"
+      }
+    }
+  },
+  "colorThemes": {
+    "accent-1": {
+      "text": {
+        "title": "green-90",
+        "primary": "green-90",
+        "secondary": "green-70",
+        "accent": "green-60"
+      },
+      "background": {
+        "primary": "green-20",
+        "secondary": "green-30",
+        "inverse": "green-90",
+        "accent": "green-10"
+      },
+      "border": {
+        "primary": "green-50",
+        "secondary": "green-40"
+      }
+    },
+    "accent-2": {
+      "text": {
+        "title": "purple-90",
+        "primary": "purple-90",
+        "secondary": "purple-70",
+        "accent": "purple-60"
+      },
+      "background": {
+        "primary": "purple-20",
+        "secondary": "purple-30",
+        "accent": "purple-10"
+      },
+      "border": {
+        "primary": "purple-50",
+        "secondary": "purple-40"
       }
     }
   },

--- a/docs/index.html
+++ b/docs/index.html
@@ -149,6 +149,9 @@ title: A17 Tailwind Plugins
           <a href="./Scrollbar.html">Scrollbar</a> - scrollbar styling, unifies
           the CSS standard and non-standard scrollbar styling
         </li>
+        <li>
+          <a href="./ColorThemes.html">ColorThemes</a> - generates token-based color themes
+        </li>
       </ul>
     </div>
     <div class="border-t border-t-secondary pt-20">

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -20,6 +20,7 @@ const {
   PseudoElements,
   InteractionMediaQueries,
   RatioBox,
+  ColorThemes,
 } = require('../index');
 
 // conf
@@ -48,6 +49,7 @@ module.exports = {
     PseudoElements,
     InteractionMediaQueries,
     RatioBox,
+    ColorThemes,
   ],
   theme: {
     screens: feConfig.structure.breakpoints,
@@ -61,6 +63,7 @@ module.exports = {
     ratios: feConfig.ratios,
     css: feConfig.css,
     colors: feConfig.color.tokens,
+    colorThemes: feConfig.colorThemes,
     borderColor: ApplyColorVariables(
       feConfig.color.tokens,
       feConfig.color.border

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -87,6 +87,15 @@ module.exports = {
         feConfig.color.scrollbar.thumb
       ),
     },
+    outlineColor: ApplyColorVariables(
+      feConfig.color.tokens,
+      feConfig.color.outline
+    ),
+    ringColor: ApplyColorVariables(feConfig.color.tokens, feConfig.color.ring),
+    ringOffsetColor: ApplyColorVariables(
+      feConfig.color.tokens,
+      feConfig.color['ring-offset']
+    ),
   },
   extend: {
     spacing: {

--- a/docs/tailwind.css
+++ b/docs/tailwind.css
@@ -1,2 +1,5707 @@
-/*! tailwindcss v4.1.5 | MIT License | https://tailwindcss.com */
-@layer properties{@supports (((-webkit-hyphens:none)) and (not (margin-trim:inline))) or ((-moz-orient:inline) and (not (color:rgb(from red r g b)))){*,:before,:after,::backdrop{--tw-rotate-x:initial;--tw-rotate-y:initial;--tw-rotate-z:initial;--tw-skew-x:initial;--tw-skew-y:initial;--tw-border-style:solid;--tw-font-weight:initial;--tw-blur:initial;--tw-brightness:initial;--tw-contrast:initial;--tw-grayscale:initial;--tw-hue-rotate:initial;--tw-invert:initial;--tw-opacity:initial;--tw-saturate:initial;--tw-sepia:initial;--tw-drop-shadow:initial;--tw-drop-shadow-color:initial;--tw-drop-shadow-alpha:100%;--tw-drop-shadow-size:initial;--tw-ease:initial;--tw-content:""}}}@layer theme{:root,:host{--spacing:1px;--font-weight-bold:700;--ease-in-out:cubic-bezier(.4,0,.2,1);--default-transition-duration:.15s;--default-transition-timing-function:cubic-bezier(.4,0,.2,1)}}@layer base{*,:after,:before,::backdrop{box-sizing:border-box;border:0 solid;margin:0;padding:0}::file-selector-button{box-sizing:border-box;border:0 solid;margin:0;padding:0}html,:host{-webkit-text-size-adjust:100%;tab-size:4;line-height:1.5;font-family:var(--default-font-family,ui-sans-serif,system-ui,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji");font-feature-settings:var(--default-font-feature-settings,normal);font-variation-settings:var(--default-font-variation-settings,normal);-webkit-tap-highlight-color:transparent}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;-webkit-text-decoration:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,samp,pre{font-family:var(--default-mono-font-family,ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace);font-feature-settings:var(--default-mono-font-feature-settings,normal);font-variation-settings:var(--default-mono-font-variation-settings,normal);font-size:1em}small{font-size:80%}sub,sup{vertical-align:baseline;font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}:-moz-focusring{outline:auto}progress{vertical-align:baseline}summary{display:list-item}ol,ul,menu{list-style:none}img,svg,video,canvas,audio,iframe,embed,object{vertical-align:middle;display:block}img,video{max-width:100%;height:auto}button,input,select,optgroup,textarea{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}::file-selector-button{font:inherit;font-feature-settings:inherit;font-variation-settings:inherit;letter-spacing:inherit;color:inherit;opacity:1;background-color:#0000;border-radius:0}:where(select:is([multiple],[size])) optgroup{font-weight:bolder}:where(select:is([multiple],[size])) optgroup option{padding-inline-start:20px}::file-selector-button{margin-inline-end:4px}::placeholder{opacity:1}@supports (not ((-webkit-appearance:-apple-pay-button))) or (contain-intrinsic-size:1px){::placeholder{color:currentColor}@supports (color:color-mix(in lab, red, red)){::placeholder{color:color-mix(in oklab,currentcolor 50%,transparent)}}}textarea{resize:vertical}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-date-and-time-value{min-height:1lh;text-align:inherit}::-webkit-datetime-edit{display:inline-flex}::-webkit-datetime-edit-fields-wrapper{padding:0}::-webkit-datetime-edit{padding-block:0}::-webkit-datetime-edit-year-field{padding-block:0}::-webkit-datetime-edit-month-field{padding-block:0}::-webkit-datetime-edit-day-field{padding-block:0}::-webkit-datetime-edit-hour-field{padding-block:0}::-webkit-datetime-edit-minute-field{padding-block:0}::-webkit-datetime-edit-second-field{padding-block:0}::-webkit-datetime-edit-millisecond-field{padding-block:0}::-webkit-datetime-edit-meridiem-field{padding-block:0}:-moz-ui-invalid{box-shadow:none}button,input:where([type=button],[type=reset],[type=submit]){appearance:button}::file-selector-button{appearance:button}::-webkit-inner-spin-button{height:auto}::-webkit-outer-spin-button{height:auto}[hidden]:where(:not([hidden=until-found])){display:none!important}:root{--breakpoint:"xs";--container-width:unset;--inner-gutter:10px;--outer-gutter:20px;--grid-columns:4;--env:"dev";--grid-column-bg:#7fffff40}@media (min-width:544px){:root{--breakpoint:"sm";--container-width:unset;--inner-gutter:15px;--outer-gutter:30px;--grid-columns:4}}@media (min-width:650px){:root{--breakpoint:"md";--container-width:unset;--inner-gutter:20px;--outer-gutter:40px;--grid-columns:8}}@media (min-width:990px){:root{--breakpoint:"lg";--container-width:unset;--inner-gutter:30px;--outer-gutter:40px;--grid-columns:12}}@media (min-width:1300px){:root{--breakpoint:"xl";--container-width:unset;--inner-gutter:40px;--outer-gutter:40px;--grid-columns:12}}@media (min-width:1520px){:root{--breakpoint:"xxl";--container-width:1440px;--inner-gutter:40px;--outer-gutter:0px;--grid-columns:12}}:root{--color-white:#fff;--color-grey-3:#f8f8f8;--color-grey-5:#f2f2f2;--color-grey-10:#e6e6e6;--color-grey-15:#d9d9d9;--color-grey-30:#b3b3b3;--color-grey-54:#757575;--color-grey-90:#1a1a1a;--color-black:#000;--color-blue-01:#0a152b;--color-blue-02:#001f5c;--color-blue-03:#004f91;--color-blue-04:#313bfb;--color-blue-05:#81eef3;--color-blue-06:#add8e6;--color-red-01:red;--font-sans:SuisseIntl,Helvetica,Arial,sans-serif;--font-serif:"Times New Roman",Georgia,serif;--font-mono:"Lucida Console",Courier,monospace;--f-h1-font-family:var(--font-sans);--f-h1-font-weight:500;--f-h1-font-size:2rem;--f-h1-line-height:1.2;--f-h1-letter-spacing:-.02em;--f-h1--moz-osx-font-smoothing:grayscale;--f-h1--webkit-font-smoothing:antialiased;--f-h1---bold-weight:500;--f-h2-font-family:var(--font-sans);--f-h2-font-weight:500;--f-h2-font-size:1.25rem;--f-h2-line-height:1.2;--f-h2-letter-spacing:-.02em;--f-h2--moz-osx-font-smoothing:grayscale;--f-h2--webkit-font-smoothing:antialiased;--f-h2---bold-weight:500;--f-h3-font-family:var(--font-sans);--f-h3-font-weight:500;--f-h3-font-size:1rem;--f-h3-line-height:1.2;--f-h3-letter-spacing:-.02em;--f-h3--moz-osx-font-smoothing:grayscale;--f-h3--webkit-font-smoothing:antialiased;--f-h3---bold-weight:500;--f-h4-font-family:var(--font-sans);--f-h4-font-weight:600;--f-h4-font-size:.875rem;--f-h4-line-height:1.2;--f-h4-letter-spacing:-.02em;--f-h4--moz-osx-font-smoothing:grayscale;--f-h4--webkit-font-smoothing:antialiased;--f-h4---bold-weight:600;--f-body-font-family:var(--font-sans);--f-body-font-size:.875rem;--f-body-line-height:1.7;--f-body--moz-osx-font-smoothing:grayscale;--f-body--webkit-font-smoothing:antialiased;--f-body---bold-weight:600;--f-ui-font-family:var(--font-sans);--f-ui-font-size:.75rem;--f-ui-line-height:1.2;--f-ui-font-weight:400;--f-code-font-family:var(--font-mono);--f-code-font-size:.875rem;--f-code-line-height:1.2;--f-code-font-weight:400}@media (min-width:650px){:root{--f-h1-font-size:2.25rem;--f-h2-font-size:1.5rem;--f-h3-font-size:1.25rem;--f-h4-font-size:1rem;--f-body-font-size:1rem}}@media (min-width:990px){:root{--f-h1-font-size:3rem;--f-h2-font-size:1.75rem}}:root{--spacing-outer-1:4rem;--spacing-inner-1:1.5rem;--spacing-inner-2:1rem}@media (min-width:650px){:root{--spacing-inner-1:2.5rem;--spacing-inner-2:1.5rem}}@media (min-width:990px){:root{--spacing-outer-1:6rem;--spacing-inner-1:4rem;--spacing-inner-2:2rem}}}@layer components{.show-grid{--grid-column-bg:#0000000d;position:relative}.show-grid:after{z-index:1;width:calc(var(--container-width,100%) - (2*var(--outer-gutter,0)));background:repeating-linear-gradient(90deg,var(--grid-column-bg),var(--grid-column-bg)calc((100% - (((var(--grid-columns) - 1)*var(--inner-gutter))))/var(--grid-columns)),#0000 calc((100% - (((var(--grid-columns) - 1)*var(--inner-gutter))))/var(--grid-columns)),#0000 calc((100% - (((var(--grid-columns) - 1)*var(--inner-gutter))))/var(--grid-columns) + var(--inner-gutter)));pointer-events:none;--tw-content:"";content:var(--tw-content);inset-inline:0;width:100%;height:100%;margin:0 auto;position:absolute;top:0;bottom:0}.blockquote{background-color:var(--color-grey-5);padding-block:calc(var(--spacing)*20)}.blockquote blockquote{padding-inline:calc(var(--spacing)*20);display:block}@media (min-width:650px){.blockquote blockquote{padding-inline:calc(var(--spacing)*40)}}.blockquote blockquote p{font-style:italic}.blockquote blockquote p:first-child{margin-top:calc(var(--spacing)*0);position:relative}.blockquote blockquote p:first-child:before{content:open-quote;top:calc(var(--spacing)*0);right:100%;left:calc(var(--spacing)*-8);position:absolute}.blockquote blockquote p:last-child:after{content:close-quote}.blockquote figcaption{margin-top:calc(var(--spacing)*8);padding-inline:calc(var(--spacing)*20);display:block}@media (min-width:650px){.blockquote figcaption{padding-inline:calc(var(--spacing)*40)}}.blockquote cite{font-style:normal}.blockquote cite:before{content:"—";margin-right:calc(var(--spacing)*8)}.code-example{background-color:var(--color-grey-90);display:block}.code-example .code-example-filename{border-bottom-style:var(--tw-border-style);border-bottom-width:1px;border-color:var(--color-blue-05);padding-inline:calc(var(--spacing)*20);padding-block:calc(var(--spacing)*12);font-family:var(--f-ui-font-family);font-weight:var(--f-ui-font-weight);font-size:var(--f-ui-font-size);line-height:var(--f-ui-line-height);letter-spacing:var(--f-ui-letter-spacing);-moz-osx-font-smoothing:var(--f-ui--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-ui--webkit-font-smoothing);color:var(--color-white);min-width:160px;display:inline-block}.code-example .code-example-filename b,.code-example .code-example-filename strong{font-weight:var(--f-ui---bold-weight,bold)}.code-example .code-example-code{background-color:var(--color-grey-90);font-family:var(--f-code-font-family);font-weight:var(--f-code-font-weight);font-size:var(--f-code-font-size);line-height:var(--f-code-line-height);letter-spacing:var(--f-code-letter-spacing);-moz-osx-font-smoothing:var(--f-code--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-code--webkit-font-smoothing);color:var(--color-grey-3);display:block}.code-example .code-example-code b,.code-example .code-example-code strong{font-weight:var(--f-code---bold-weight,bold)}.code-example .code-example-code code{max-height:calc(var(--spacing)*600);background-color:var(--color-grey-90);scrollbar-color:var(--grey-54)var(--grey-90);scrollbar-width:thin;overflow:auto}.code-example .code-example-code code::-webkit-scrollbar{width:8px;height:8px}.code-example .code-example-code code::-webkit-scrollbar-track{background:var(--grey-90)}.code-example .code-example-code code::-webkit-scrollbar-thumb{background:var(--grey-54);width:8px;height:8px}.copy h2{font-family:var(--f-h2-font-family);font-weight:var(--f-h2-font-weight);font-size:var(--f-h2-font-size);line-height:var(--f-h2-line-height);letter-spacing:var(--f-h2-letter-spacing);-moz-osx-font-smoothing:var(--f-h2--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h2--webkit-font-smoothing)}.copy h2 b,.copy h2 strong{font-weight:var(--f-h2---bold-weight,bold)}.copy h2:not(:first-child){margin-top:calc(var(--spacing)*56);border-top-style:var(--tw-border-style);border-top-width:1px;border-color:var(--color-grey-30);padding-top:calc(var(--spacing)*48)}.copy h3{margin-top:calc(var(--spacing)*40);font-family:var(--f-h3-font-family);font-weight:var(--f-h3-font-weight);font-size:var(--f-h3-font-size);line-height:var(--f-h3-line-height);letter-spacing:var(--f-h3-letter-spacing);-moz-osx-font-smoothing:var(--f-h3--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h3--webkit-font-smoothing)}.copy h3 b,.copy h3 strong{font-weight:var(--f-h3---bold-weight,bold)}.copy h4{margin-top:calc(var(--spacing)*40);font-family:var(--f-h4-font-family);font-weight:var(--f-h4-font-weight);font-size:var(--f-h4-font-size);line-height:var(--f-h4-line-height);letter-spacing:var(--f-h4-letter-spacing);-moz-osx-font-smoothing:var(--f-h4--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h4--webkit-font-smoothing)}.copy h4 b,.copy h4 strong{font-weight:var(--f-h4---bold-weight,bold)}.copy p{margin-top:calc(var(--spacing)*20);font-family:var(--f-body-font-family);font-weight:var(--f-body-font-weight);font-size:var(--f-body-font-size);line-height:var(--f-body-line-height);letter-spacing:var(--f-body-letter-spacing);-moz-osx-font-smoothing:var(--f-body--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-body--webkit-font-smoothing)}.copy p b,.copy p strong{font-weight:var(--f-body---bold-weight,bold)}.copy p:first-child{margin-top:calc(var(--spacing)*0)}.copy ul{margin-top:calc(var(--spacing)*20);padding-left:calc(var(--spacing)*16);font-family:var(--f-body-font-family);font-weight:var(--f-body-font-weight);font-size:var(--f-body-font-size);line-height:var(--f-body-line-height);letter-spacing:var(--f-body-letter-spacing);-moz-osx-font-smoothing:var(--f-body--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-body--webkit-font-smoothing);list-style-type:disc}.copy ul b,.copy ul strong{font-weight:var(--f-body---bold-weight,bold)}.copy ul ul{margin-top:calc(var(--spacing)*0)}.copy ol{margin-top:calc(var(--spacing)*20);padding-left:calc(var(--spacing)*16);font-family:var(--f-body-font-family);font-weight:var(--f-body-font-weight);font-size:var(--f-body-font-size);line-height:var(--f-body-line-height);letter-spacing:var(--f-body-letter-spacing);-moz-osx-font-smoothing:var(--f-body--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-body--webkit-font-smoothing);list-style-type:decimal}.copy ol b,.copy ol strong{font-weight:var(--f-body---bold-weight,bold)}.copy .code-example{margin-top:calc(var(--spacing)*20)}.copy code:not([class]){background-color:var(--color-white);padding-inline:calc(var(--spacing)*8);padding-top:calc(var(--spacing)*4);padding-bottom:calc(var(--spacing)*2);font-family:var(--f-code-font-family);font-weight:var(--f-code-font-weight);font-size:var(--f-code-font-size);line-height:var(--f-code-line-height);letter-spacing:var(--f-code-letter-spacing);-moz-osx-font-smoothing:var(--f-code--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-code--webkit-font-smoothing);color:var(--color-black)}.copy code:not([class]) b,.copy code:not([class]) strong{font-weight:var(--f-code---bold-weight,bold)}.copy pre:not([class]){margin-top:calc(var(--spacing)*20);max-height:calc(var(--spacing)*400);font-family:var(--f-code-font-family);font-weight:var(--f-code-font-weight);font-size:var(--f-code-font-size);line-height:var(--f-code-line-height);letter-spacing:var(--f-code-letter-spacing);-moz-osx-font-smoothing:var(--f-code--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-code--webkit-font-smoothing);display:block;overflow-y:scroll}.copy pre:not([class]) b,.copy pre:not([class]) strong{font-weight:var(--f-code---bold-weight,bold)}.copy pre:not([class]) code:not([class]){padding:calc(var(--spacing)*8);display:block}.copy a{color:var(--color-blue-03);text-decoration-line:underline}.copy a:hover,.copy a:focus{color:var(--color-grey-90)}.copy hr{margin-block:calc(var(--spacing)*40);border-color:var(--color-grey-30)}.copy .blockquote{margin-top:calc(var(--spacing)*20)}@media (min-width:768px){.copy>:not(.code-example,h2,hr){max-width:80%}}@media (min-width:1024px){.copy>:not(.code-example,h2,hr){max-width:60%}}.copy table{margin-top:calc(var(--spacing)*20)}.copy th,.copy td{border-left-style:var(--tw-border-style);border-left-width:1px;border-color:var(--color-grey-30);padding-inline:calc(var(--spacing)*10);padding-bottom:calc(var(--spacing)*4)}.copy th:first-child,.copy td:first-child{border-left-style:var(--tw-border-style);border-left-width:0;padding-inline-start:calc(var(--spacing)*0)}.copy th:last-child,.copy td:last-child{padding-inline-end:calc(var(--spacing)*0)}}@layer utilities{.dev-tools-grid{z-index:1;width:calc(var(--container-width,100%) - (2*var(--outer-gutter,0)));background:repeating-linear-gradient(90deg,var(--grid-column-bg),var(--grid-column-bg)calc((100% - (((var(--grid-columns) - 1)*var(--inner-gutter))))/var(--grid-columns)),#0000 calc((100% - (((var(--grid-columns) - 1)*var(--inner-gutter))))/var(--grid-columns)),#0000 calc((100% - (((var(--grid-columns) - 1)*var(--inner-gutter))))/var(--grid-columns) + var(--inner-gutter)));pointer-events:none;inset-inline:0;height:100%;margin:0 auto;position:fixed;top:0;bottom:0}.grid-line-yfull>*{position:relative}.grid-line-yfull>:before,.grid-line-yfull>:after{z-index:0;pointer-events:none;position:absolute}.grid-line-yfull>:after{content:"";inset-inline-start:0;inset-inline-end:calc(var(--inner-gutter)/-2);top:var(--gridline-y-top,calc(var(--inner-gutter)/-1));border-inline-start:0 solid #0000;border-inline-end:var(--gridline-y-width,0)solid var(--gridline-y-color,transparent);bottom:0}.grid-line-yfull.grid-line-x>:after,.grid-line-yfull.grid-line-xfull>:after{inset-inline-start:0;inset-inline-end:calc(var(--inner-gutter)/-2);top:var(--gridline-y-top,calc(var(--inner-gutter)/-2));bottom:var(--gridline-y-bottom,calc(var(--inner-gutter)/-2));border-inline-start:0 solid #0000;border-inline-end:var(--gridline-y-width,0)solid var(--gridline-y-color,transparent)}.grid-line-x>*{position:relative}.grid-line-x>:before,.grid-line-x>:after{z-index:0;pointer-events:none;position:absolute}.grid-line-x>:before{content:"";inset-inline-start:var(--gridline-x-start,0);inset-inline-end:var(--gridline-x-end,0);top:0;bottom:var(--gridline-x-bottom,calc(var(--inner-gutter)/-2));border-top:0 solid #0000;border-bottom:var(--gridline-x-width,0)solid var(--gridline-x-color,transparent)}.grid-line-xfull>*{position:relative}.grid-line-xfull>:before,.grid-line-xfull>:after{z-index:0;pointer-events:none;position:absolute}.grid-line-xfull>:before{content:"";inset-inline-start:var(--gridline-x-start,calc(var(--inner-gutter)/-2));inset-inline-end:var(--gridline-x-end,calc(var(--inner-gutter)/-2));top:0;bottom:var(--gridline-x-bottom,calc(var(--inner-gutter)/-2));border-top:0 solid #0000;border-bottom:var(--gridline-x-width,0)solid var(--gridline-x-color,transparent)}.grid-line-y>*{position:relative}.grid-line-y>:before,.grid-line-y>:after{z-index:0;pointer-events:none;position:absolute}.grid-line-y>:after{content:"";border-inline-start:0 solid #0000;border-inline-end:var(--gridline-y-width,0)solid var(--gridline-y-color,transparent);inset-inline-start:0;inset-inline-end:calc(var(--inner-gutter)/-2);top:0;bottom:0}.keyline-l-primary{--keyline-l-color:var(--color-grey-90);--keyline-r-color:transparent;position:relative}.keyline-l-primary:before{content:"";z-index:0;border-left:1px solid var(--keyline-l-color,transparent);border-right:1px solid var(--keyline-r-color,transparent);pointer-events:none;inset-inline-start:calc(var(--inner-gutter)/-2 - 1px);inset-inline-end:calc(var(--inner-gutter)/-2);position:absolute;top:0;bottom:0}.keyline-r-primary{--keyline-l-color:transparent;--keyline-r-color:var(--color-grey-90);position:relative}.keyline-r-primary:before{content:"";z-index:0;border-left:1px solid var(--keyline-l-color,transparent);border-right:1px solid var(--keyline-r-color,transparent);pointer-events:none;inset-inline-start:calc(var(--inner-gutter)/-2 - 1px);inset-inline-end:calc(var(--inner-gutter)/-2);position:absolute;top:0;bottom:0}.background-fill{--background-fill-bg:inherit;position:relative}.background-fill:before{content:"";z-index:-1;background-color:var(--background-fill-bg,inherit);pointer-events:none;inset-inline-start:50%;width:100vw;margin-inline-start:-50vw;position:absolute;top:0;bottom:0}.background-fill-accent{--background-fill-bg:var(--color-blue-03);position:relative}.background-fill-accent:before{content:"";z-index:-1;background-color:var(--background-fill-bg,inherit);pointer-events:none;inset-inline-start:50%;width:100vw;margin-inline-start:-50vw;position:absolute;top:0;bottom:0}.background-fill-header{--background-fill-bg:var(--color-grey-10);position:relative}.background-fill-header:before{content:"";z-index:-1;background-color:var(--background-fill-bg,inherit);pointer-events:none;inset-inline-start:50%;width:100vw;margin-inline-start:-50vw;position:absolute;top:0;bottom:0}.stroke-full-top{--stroke-full-thickness:.0625em;--stroke-full-style:solid;--stroke-full-color:inherit;position:relative}.stroke-full-top:after{content:"";z-index:-1;pointer-events:none;border-bottom:var(--stroke-full-thickness,.0625em)var(--stroke-full-style,solid)var(--stroke-full-color,inherit);inset-inline-start:50%;width:100vw;margin-inline-start:-50vw;position:absolute;top:0;bottom:100%}.stroke-full-bottom{--stroke-full-thickness:.0625em;--stroke-full-style:solid;--stroke-full-color:inherit;position:relative}.stroke-full-bottom:after{content:"";z-index:-1;pointer-events:none;border-top:var(--stroke-full-thickness,.0625em)var(--stroke-full-style,solid)var(--stroke-full-color,inherit);inset-inline-start:50%;width:100vw;margin-inline-start:-50vw;position:absolute;top:100%}.dev-tools{z-index:2147483647;inset-inline-start:0;font-size:0;position:fixed;bottom:0}.dev-tools:before{content:var(--breakpoint)" • " var(--env);z-index:2;color:#fff;white-space:nowrap;pointer-events:none;inset-inline-start:0;background:green;padding:4px 5px;font:12px/1 sans-serif;position:absolute;bottom:100%}.grid-line-x-0>*{position:relative}.grid-line-x-0>:before,.grid-line-x-0>:after{z-index:0;pointer-events:none;position:absolute}.grid-line-x-0>:before{content:none}.grid-line-y-0>*{position:relative}.grid-line-y-0>:before,.grid-line-y-0>:after{z-index:0;pointer-events:none;position:absolute}.grid-line-y-0>:after{content:none}.pointer-events-none{pointer-events:none}.collapse{visibility:collapse}.invisible{visibility:hidden}.visible{visibility:visible}.dev-tools-toggle{z-index:2;color:#0000;width:30px;height:30px;font:0/0 a;appearance:none;cursor:pointer;background:#000;border:0;position:relative}.dev-tools-toggle:before,.dev-tools-toggle:after{content:"";inset-inline-start:8px;border-inline:1px solid #fff;width:5px;height:10px;position:absolute;top:10px}.dev-tools-toggle:after{inset-inline-start:16px}.container[class]{width:calc(var(--container-width,100%) - (2*var(--breakout-container-outer-gutter,var(--container-outer-gutter,var(--outer-gutter,0)))));margin-left:auto;margin-right:auto}.container[class]>*{--container-outer-gutter:0;--breakout-container-outer-gutter:0}.container[class]>.breakout[class],.breakout[class],.container[class]>.breakout[class]{--breakout-outer-gutter:max(var(--outer-gutter),calc((100% - var(--container-width,100%))/2));--breakout-container-outer-gutter:var(--outer-gutter);width:calc(100vw - var(--scrollbar-visible-width,0px));margin-inline-start:calc((100vw - var(--scrollbar-visible-width,0px))/-2);position:relative;inset-inline-start:50%}.ratio{--ratio:100%;display:block;position:relative;overflow:hidden}.ratio:before{content:"";width:100%;height:0;padding-bottom:var(--ratio);display:block}.ratio>[class*=ratio-content]{width:100%;height:100%;position:absolute;inset:0}.ratio-free:before,.ratio-free:after{content:unset}.ratio-free>[class*=ratio-content]{width:auto;height:auto;position:static;inset:auto}.ratio-free>[class*=ratio-content][class*=w-full]{width:100%}.ratio-free>[class*=ratio-content][class*=h-auto]{height:auto}.absolute{position:absolute}.fixed{position:fixed}.relative{position:relative}.static{position:static}.grid-line-yfull.grid-line-x>:after,.grid-line-yfull.grid-line-xfull>:after{inset-inline-start:0;inset-inline-end:calc(var(--inner-gutter)/-2);top:var(--gridline-y-top,calc(var(--inner-gutter)/-2));bottom:var(--gridline-y-bottom,calc(var(--inner-gutter)/-2));border-inline-start:0 solid #0000;border-inline-end:var(--gridline-y-width,0)solid var(--gridline-y-color,transparent)}.start-cols-2{inset-inline-start:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.end-cols-4{inset-inline-end:calc(((((4/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (4/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.top-0{top:calc(var(--spacing)*0)}.top-40{top:calc(var(--spacing)*40)}.top-56{top:calc(var(--spacing)*56)}.top-60{top:calc(var(--spacing)*60)}.top-\[var\(--offset\)\]{top:var(--offset)}.right-0{right:calc(var(--spacing)*0)}.right-full{right:100%}.-left-8{left:calc(var(--spacing)*-8)}.-left-99999{left:calc(var(--spacing)*-99999)}.left-0{left:calc(var(--spacing)*0)}.left-\[-99999px\]{left:-99999px}.left-cols-1{left:calc(((((1/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (1/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.left-cols-1\/3{left:calc(((33.333% - (var(--inner-gutter)*max(.666,var(--cols-container,0)))) + var(--inner-gutter)))}.grid-col-span-1{--container-grid-columns:1;grid-column:span 1/span 1}.grid-col-span-2{--container-grid-columns:2;grid-column:span 2/span 2}.grid-col-span-3{--container-grid-columns:3;grid-column:span 3/span 3}.grid-col-span-6{--container-grid-columns:6;grid-column:span 6/span 6}.grid-col-span-8{--container-grid-columns:8;grid-column:span 8/span 8}.grid-col-span-9{--container-grid-columns:9;grid-column:span 9/span 9}.grid-col-start-1{grid-column-start:1}.grid-col-start-4{grid-column-start:4}.grid-col-end-1{grid-column-end:1}.grid-col-end-13{grid-column-end:13}.row-span-3{grid-row:span 3/span 3}.row-span-full{grid-row:1/-1}.row-end-3{grid-row-end:3}.ratio-expandable:before{float:left;width:1px;margin-inline-start:-1px}.ratio-expandable:after{content:"";clear:both;display:table}.container{width:100%}@media (min-width:0){.container{max-width:0}}@media (min-width:544px){.container{max-width:544px}}@media (min-width:650px){.container{max-width:650px}}@media (min-width:990px){.container{max-width:990px}}@media (min-width:1300px){.container{max-width:1300px}}@media (min-width:1520px){.container{max-width:1520px}}.m-0{margin:calc(var(--spacing)*0)}.mx-40{margin-inline:calc(var(--spacing)*40)}.mx-auto{margin-inline:auto}.mx-cols-1{margin-inline:calc(((((1/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (1/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.mx-cols-3{margin-inline:calc(((((3/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (3/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.mx-outer-1{margin-inline:var(--spacing-outer-1)}.my-40{margin-block:calc(var(--spacing)*40)}.ms-0{margin-inline-start:calc(var(--spacing)*0)}.ms-cols-2{margin-inline-start:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.me-cols-2{margin-inline-end:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.-mt-\(--spacing-outer-1\){margin-top:calc(var(--spacing-outer-1)*-1)}.mt-\(--spacing-outer-1\){margin-top:var(--spacing-outer-1)}.mt-0{margin-top:calc(var(--spacing)*0)}.mt-1{margin-top:calc(var(--spacing)*1)}.mt-4{margin-top:calc(var(--spacing)*4)}.mt-8{margin-top:calc(var(--spacing)*8)}.mt-16{margin-top:calc(var(--spacing)*16)}.mt-20{margin-top:calc(var(--spacing)*20)}.mt-40{margin-top:calc(var(--spacing)*40)}.mt-56{margin-top:calc(var(--spacing)*56)}.mt-60{margin-top:calc(var(--spacing)*60)}.mt-outer-1{margin-top:var(--spacing-outer-1)}.mr-8{margin-right:calc(var(--spacing)*8)}.mr-cols-1{margin-right:calc(((((1/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (1/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.mr-cols-2{margin-right:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.mr-cols-vw-2{margin-right:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*2) + (1*var(--inner-gutter)))}.mb-16{margin-bottom:calc(var(--spacing)*16)}.mb-60{margin-bottom:calc(var(--spacing)*60)}.cols-container{margin-left:calc(var(--inner-gutter)*-1);flex-flow:wrap;display:flex}.cols-container>[class*=-cols]{--cols-container:1;margin-left:var(--inner-gutter)}.cols-container>.ml-0,.cols-container>.ms-0{margin-left:0}.ml-0{margin-left:calc(var(--spacing)*0)}.ml-16{margin-left:calc(var(--spacing)*16)}.ml-auto{margin-left:auto}.ml-cols-2{margin-left:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.ml-cols-2\/3{margin-left:calc(((66.666% - (var(--inner-gutter)*max(.333,var(--cols-container,0)))) + var(--inner-gutter)))}.ml-cols-no-gutter-2{margin-left:calc(((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.ml-cols-vw-2{margin-left:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*2) + (1*var(--inner-gutter)))}.full-bleed-scroller-reset{display:unset;flex-flow:unset;flex-wrap:unset;overflow-x:unset}.full-bleed-scroller-reset:before,.full-bleed-scroller-reset:after{content:none;flex:unset;width:unset}.full-bleed-scroller{gap:var(--inner-gutter);flex-flow:row;display:flex;overflow:auto hidden}.full-bleed-scroller:before,.full-bleed-scroller:after{content:"";width:calc(var(--breakout-outer-gutter,var(--outer-gutter,0px)) - var(--inner-gutter,0px));flex:none}.grid-layout{grid-template-columns:repeat(var(--container-grid-columns,var(--grid-columns)),1fr);grid-gap:var(--inner-gutter);display:grid}.scrollbar-none{-ms-overflow-style:none;scrollbar-width:none}.scrollbar-none::-webkit-scrollbar{display:none}.block{display:block}.flex{display:flex}.grid{display:grid}.hidden{display:none}.inline{display:inline}.inline-block{display:inline-block}.table{display:table}.scrollbar-thin{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-thin::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-thin::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-thin::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-thin::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-thin::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-thin-collapse{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-thin-collapse::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-thin-collapse::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-thin-collapse::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-thin-collapse::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-thin-collapse::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-thumb-bg-column-alt{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-thumb-bg-column-alt::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-thumb-bg-column-alt::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-thumb-bg-column-alt::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-thumb-bg-column-alt::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-thumb-bg-column-alt::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-thumb-primary{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-thumb-primary::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-thumb-primary::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-thumb-primary::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-thumb-primary::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-thumb-primary::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-thumb-red-01{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-thumb-red-01::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-thumb-red-01::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-thumb-red-01::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-thumb-red-01::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-thumb-red-01::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-track-bg-column{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-track-bg-column::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-track-bg-column::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-track-bg-column::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-track-bg-column::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-track-bg-column::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-track-grey-15{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-track-grey-15::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-track-grey-15::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-track-grey-15::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-track-grey-15::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-track-grey-15::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.scrollbar-track-primary{--scrollbar-bg:#fafafa;--scrollbar-fg:#c1c1c1;--scrollbar-border:#e8e8e8;scrollbar-color:var(--scrollbar-fg)var(--scrollbar-bg)}.scrollbar-track-primary::-webkit-scrollbar{width:var(--scrollbar-width,unset);height:var(--scrollbar-width,unset)}.scrollbar-track-primary::-webkit-scrollbar-track{background:var(--scrollbar-bg)}.scrollbar-track-primary::-webkit-scrollbar-track:horizontal{border-block-start:1px solid var(--scrollbar-border);border-block-end:1px solid var(--scrollbar-border)}.scrollbar-track-primary::-webkit-scrollbar-track:vertical{border-inline-start:1px solid var(--scrollbar-border);border-inline-end:1px solid var(--scrollbar-border)}.scrollbar-track-primary::-webkit-scrollbar-thumb{background:var(--scrollbar-fg);border:var(--scrollbar-padding,4px)solid transparent;background-clip:content-box;border-radius:20px}.h-0{height:calc(var(--spacing)*0)}.h-1{height:calc(var(--spacing)*1)}.h-2{height:calc(var(--spacing)*2)}.h-3{height:calc(var(--spacing)*3)}.h-4{height:calc(var(--spacing)*4)}.h-5{height:calc(var(--spacing)*5)}.h-6{height:calc(var(--spacing)*6)}.h-7{height:calc(var(--spacing)*7)}.h-8{height:calc(var(--spacing)*8)}.h-9{height:calc(var(--spacing)*9)}.h-10{height:calc(var(--spacing)*10)}.h-12{height:calc(var(--spacing)*12)}.h-16{height:calc(var(--spacing)*16)}.h-20{height:calc(var(--spacing)*20)}.h-24{height:calc(var(--spacing)*24)}.h-28{height:calc(var(--spacing)*28)}.h-32{height:calc(var(--spacing)*32)}.h-36{height:calc(var(--spacing)*36)}.h-40{height:calc(var(--spacing)*40)}.h-44{height:calc(var(--spacing)*44)}.h-48{height:calc(var(--spacing)*48)}.h-52{height:calc(var(--spacing)*52)}.h-56{height:calc(var(--spacing)*56)}.h-60{height:calc(var(--spacing)*60)}.h-64{height:calc(var(--spacing)*64)}.h-68{height:calc(var(--spacing)*68)}.h-72{height:calc(var(--spacing)*72)}.h-76{height:calc(var(--spacing)*76)}.h-80{height:calc(var(--spacing)*80)}.h-84{height:calc(var(--spacing)*84)}.h-88{height:calc(var(--spacing)*88)}.h-92{height:calc(var(--spacing)*92)}.h-96{height:calc(var(--spacing)*96)}.h-100{height:calc(var(--spacing)*100)}.h-120{height:calc(var(--spacing)*120)}.h-400{height:calc(var(--spacing)*400)}.h-600{height:calc(var(--spacing)*600)}.h-auto{height:auto}.max-h-400{max-height:calc(var(--spacing)*400)}.max-h-600{max-height:calc(var(--spacing)*600)}.min-h-0{min-height:calc(var(--spacing)*0)}.min-h-40{min-height:calc(var(--spacing)*40)}.min-h-screen{min-height:100vh}.w-0{width:calc(var(--spacing)*0)}.w-1{width:calc(var(--spacing)*1)}.w-2{width:calc(var(--spacing)*2)}.w-3{width:calc(var(--spacing)*3)}.w-4{width:calc(var(--spacing)*4)}.w-5{width:calc(var(--spacing)*5)}.w-6{width:calc(var(--spacing)*6)}.w-7{width:calc(var(--spacing)*7)}.w-8{width:calc(var(--spacing)*8)}.w-9{width:calc(var(--spacing)*9)}.w-10{width:calc(var(--spacing)*10)}.w-12{width:calc(var(--spacing)*12)}.w-16{width:calc(var(--spacing)*16)}.w-20{width:calc(var(--spacing)*20)}.w-24{width:calc(var(--spacing)*24)}.w-28{width:calc(var(--spacing)*28)}.w-32{width:calc(var(--spacing)*32)}.w-36{width:calc(var(--spacing)*36)}.w-40{width:calc(var(--spacing)*40)}.w-44{width:calc(var(--spacing)*44)}.w-48{width:calc(var(--spacing)*48)}.w-52{width:calc(var(--spacing)*52)}.w-56{width:calc(var(--spacing)*56)}.w-60{width:calc(var(--spacing)*60)}.w-64{width:calc(var(--spacing)*64)}.w-68{width:calc(var(--spacing)*68)}.w-72{width:calc(var(--spacing)*72)}.w-76{width:calc(var(--spacing)*76)}.w-80{width:calc(var(--spacing)*80)}.w-84{width:calc(var(--spacing)*84)}.w-88{width:calc(var(--spacing)*88)}.w-92{width:calc(var(--spacing)*92)}.w-96{width:calc(var(--spacing)*96)}.w-100{width:calc(var(--spacing)*100)}.w-400{width:calc(var(--spacing)*400)}.w-600{width:calc(var(--spacing)*600)}.w-cols-1{width:calc(((1/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (1/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-1\/2{width:calc(50% - (var(--inner-gutter)*max(.5,var(--cols-container,0))))}.w-cols-1\/3{width:calc(33.333% - (var(--inner-gutter)*max(.666,var(--cols-container,0))))}.w-cols-1\/4{width:calc(25% - (var(--inner-gutter)*max(.75,var(--cols-container,0))))}.w-cols-2{width:calc(((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-2\/3{width:calc(66.666% - (var(--inner-gutter)*max(.333,var(--cols-container,0))))}.w-cols-3{width:calc(((3/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (3/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-3\/4{width:calc(75% - (var(--inner-gutter)*max(.25,var(--cols-container,0))))}.w-cols-4{width:calc(((4/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (4/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-5{width:calc(((5/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (5/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-6{width:calc(((6/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (6/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-7{width:calc(((7/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (7/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-8{width:calc(((8/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (8/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-9{width:calc(((9/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (9/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-10{width:calc(((10/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (10/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-11{width:calc(((11/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (11/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-12{width:calc(((12/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (12/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.w-cols-vw-1{width:calc(((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns))))}.w-cols-vw-2{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*2) + (1*var(--inner-gutter)))}.w-cols-vw-3{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*3) + (2*var(--inner-gutter)))}.w-cols-vw-4{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*4) + (3*var(--inner-gutter)))}.w-cols-vw-5{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*5) + (4*var(--inner-gutter)))}.w-cols-vw-6{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*6) + (5*var(--inner-gutter)))}.w-cols-vw-7{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*7) + (6*var(--inner-gutter)))}.w-cols-vw-8{width:calc((((var(--container-width,100vw - var(--scrollbar-visible-width,0px)) - (((var(--grid-columns) - 1)*var(--inner-gutter)) + (2*var(--outer-gutter))))/(var(--grid-columns)))*8) + (7*var(--inner-gutter)))}.w-full{width:100%}.breakout[class]>.w-outer-gutter{width:var(--breakout-outer-gutter)}.\!max-w-full{max-width:100%!important}.container{max-width:100%}.max-w-400{max-width:calc(var(--spacing)*400)}.max-w-full{max-width:100%}.flex-none{flex:none}.flex-shrink-0,.shrink-0{flex-shrink:0}.flex-grow,.grow{flex-grow:1}.transform{transform:var(--tw-rotate-x,)var(--tw-rotate-y,)var(--tw-rotate-z,)var(--tw-skew-x,)var(--tw-skew-y,)}.cursor-pointer{cursor:pointer}.resize{resize:both}.list-decimal{list-style-type:decimal}.list-disc{list-style-type:disc}.appearance-none{appearance:none}.grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.flex-col{flex-direction:column}.flex-row{flex-direction:row}.flex-nowrap{flex-wrap:nowrap}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.justify-center{justify-content:center}.justify-end{justify-content:flex-end}.gap-gutter{grid-gap:var(--inner-gutter);gap:var(--inner-gutter)}.gap-x-gutter{grid-column-gap:var(--inner-gutter);column-gap:var(--inner-gutter)}.gap-x-0{column-gap:calc(var(--spacing)*0)}.gap-y-gutter{grid-row-gap:var(--inner-gutter);row-gap:var(--inner-gutter)}.gap-y-20{row-gap:calc(var(--spacing)*20)}.gap-y-48{row-gap:calc(var(--spacing)*48)}.gap-y-80{row-gap:calc(var(--spacing)*80)}.overflow-auto{overflow:auto}.overflow-x-auto{overflow-x:auto}.overflow-x-hidden{overflow-x:hidden}.overflow-y-scroll{overflow-y:scroll}.border{border-style:var(--tw-border-style);border-width:1px}.border-2{border-style:var(--tw-border-style);border-width:2px}.border-t{border-top-style:var(--tw-border-style);border-top-width:1px}.border-b{border-bottom-style:var(--tw-border-style);border-bottom-width:1px}.border-l-0{border-left-style:var(--tw-border-style);border-left-width:0}.border-l-1{border-left-style:var(--tw-border-style);border-left-width:1px}.border-code-example-filename{border-color:var(--color-blue-05)}.border-primary{border-color:var(--color-grey-90)}.border-secondary{border-color:var(--color-grey-30)}.border-tertiary{border-color:var(--color-grey-54)}.border-t-secondary{border-top-color:var(--color-grey-30)}.bg-accent{background-color:var(--color-blue-03)}.bg-banner{background-color:var(--color-grey-90)}.bg-code{background-color:var(--color-white)}.bg-code-example{background-color:var(--color-grey-90)}.bg-column{background-color:var(--color-blue-05)}.bg-column-alt{background-color:var(--color-blue-04)}.bg-container-demo{background-color:var(--color-white)}.bg-header,.bg-primary{background-color:var(--color-grey-10)}.bg-quote{background-color:var(--color-grey-5)}.p-\(--spacing-inner-1\){padding:var(--spacing-inner-1)}.p-8{padding:calc(var(--spacing)*8)}.p-20{padding:calc(var(--spacing)*20)}.p-inner-1{padding:var(--spacing-inner-1)}.px-4{padding-inline:calc(var(--spacing)*4)}.px-8{padding-inline:calc(var(--spacing)*8)}.px-10{padding-inline:calc(var(--spacing)*10)}.px-20{padding-inline:calc(var(--spacing)*20)}.py-2{padding-block:calc(var(--spacing)*2)}.py-12{padding-block:calc(var(--spacing)*12)}.py-20{padding-block:calc(var(--spacing)*20)}.py-24{padding-block:calc(var(--spacing)*24)}.py-40{padding-block:calc(var(--spacing)*40)}.breakout[class].px-outer-gutter,.breakout[class]>.px-outer-gutter{padding-inline-start:var(--breakout-outer-gutter);padding-inline-end:var(--breakout-outer-gutter)}.breakout[class].pl-outer-gutter,.breakout[class]>.pl-outer-gutter{padding-inline-start:var(--breakout-outer-gutter)}.ps-0{padding-inline-start:calc(var(--spacing)*0)}.ps-cols-2{padding-inline-start:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.ps-inner-1{padding-inline-start:var(--spacing-inner-1)}.breakout[class].pr-outer-gutter,.breakout[class]>.pr-outer-gutter{padding-inline-end:var(--breakout-outer-gutter)}.pe-0{padding-inline-end:calc(var(--spacing)*0)}.pe-cols-4{padding-inline-end:calc(((((4/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (4/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.pt-4{padding-top:calc(var(--spacing)*4)}.pt-20{padding-top:calc(var(--spacing)*20)}.pt-40{padding-top:calc(var(--spacing)*40)}.pt-48{padding-top:calc(var(--spacing)*48)}.pt-60{padding-top:calc(var(--spacing)*60)}.pt-inner-1{padding-top:var(--spacing-inner-1)}.pt-outer-1{padding-top:var(--spacing-outer-1)}.pr-cols-4{padding-right:calc(((((4/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (4/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.pb-2{padding-bottom:calc(var(--spacing)*2)}.pb-4{padding-bottom:calc(var(--spacing)*4)}.pb-20{padding-bottom:calc(var(--spacing)*20)}.pb-40{padding-bottom:calc(var(--spacing)*40)}.pl-3{padding-left:calc(var(--spacing)*3)}.pl-16{padding-left:calc(var(--spacing)*16)}.pl-cols-2{padding-left:calc(((((2/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (2/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.text-center{text-align:center}.align-text-bottom{vertical-align:text-bottom}.f-body{font-family:var(--f-body-font-family);font-weight:var(--f-body-font-weight);font-size:var(--f-body-font-size);line-height:var(--f-body-line-height);letter-spacing:var(--f-body-letter-spacing);-moz-osx-font-smoothing:var(--f-body--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-body--webkit-font-smoothing)}.f-body b,.f-body strong{font-weight:var(--f-body---bold-weight,bold)}.f-code{font-family:var(--f-code-font-family);font-weight:var(--f-code-font-weight);font-size:var(--f-code-font-size);line-height:var(--f-code-line-height);letter-spacing:var(--f-code-letter-spacing);-moz-osx-font-smoothing:var(--f-code--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-code--webkit-font-smoothing)}.f-code b,.f-code strong{font-weight:var(--f-code---bold-weight,bold)}.f-h1{font-family:var(--f-h1-font-family);font-weight:var(--f-h1-font-weight);font-size:var(--f-h1-font-size);line-height:var(--f-h1-line-height);letter-spacing:var(--f-h1-letter-spacing);-moz-osx-font-smoothing:var(--f-h1--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h1--webkit-font-smoothing)}.f-h1 b,.f-h1 strong{font-weight:var(--f-h1---bold-weight,bold)}.f-h2{font-family:var(--f-h2-font-family);font-weight:var(--f-h2-font-weight);font-size:var(--f-h2-font-size);line-height:var(--f-h2-line-height);letter-spacing:var(--f-h2-letter-spacing);-moz-osx-font-smoothing:var(--f-h2--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h2--webkit-font-smoothing)}.f-h2 b,.f-h2 strong{font-weight:var(--f-h2---bold-weight,bold)}.f-h3{font-family:var(--f-h3-font-family);font-weight:var(--f-h3-font-weight);font-size:var(--f-h3-font-size);line-height:var(--f-h3-line-height);letter-spacing:var(--f-h3-letter-spacing);-moz-osx-font-smoothing:var(--f-h3--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h3--webkit-font-smoothing)}.f-h3 b,.f-h3 strong{font-weight:var(--f-h3---bold-weight,bold)}.f-h4{font-family:var(--f-h4-font-family);font-weight:var(--f-h4-font-weight);font-size:var(--f-h4-font-size);line-height:var(--f-h4-line-height);letter-spacing:var(--f-h4-letter-spacing);-moz-osx-font-smoothing:var(--f-h4--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h4--webkit-font-smoothing)}.f-h4 b,.f-h4 strong{font-weight:var(--f-h4---bold-weight,bold)}.f-ui{font-family:var(--f-ui-font-family);font-weight:var(--f-ui-font-weight);font-size:var(--f-ui-font-size);line-height:var(--f-ui-line-height);letter-spacing:var(--f-ui-letter-spacing);-moz-osx-font-smoothing:var(--f-ui--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-ui--webkit-font-smoothing)}.f-ui b,.f-ui strong{font-weight:var(--f-ui---bold-weight,bold)}.font-bold{--tw-font-weight:var(--font-weight-bold);font-weight:var(--font-weight-bold)}.text-balance{text-wrap:balance}.text-accent{color:var(--color-blue-03)}.text-code{color:var(--color-black)}.text-code-example{color:var(--color-grey-3)}.text-code-example-filename{color:var(--color-blue-05)}.text-inverse{color:var(--color-white)}.text-primary{color:var(--color-grey-90)}.italic{font-style:italic}.not-italic{font-style:normal}.underline-border-primary{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-90);-webkit-text-decoration-color:var(--color-grey-90);text-decoration-color:var(--color-grey-90)}.underline-border-secondary{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-30);-webkit-text-decoration-color:var(--color-grey-30);text-decoration-color:var(--color-grey-30)}.underline-border-tertiary{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-54);-webkit-text-decoration-color:var(--color-grey-54);text-decoration-color:var(--color-grey-54)}.underline-text-primary{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-90);-webkit-text-decoration-color:var(--color-grey-90);text-decoration-color:var(--color-grey-90)}.underline-text-secondary{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-54);-webkit-text-decoration-color:var(--color-grey-54);text-decoration-color:var(--color-grey-54)}.underline-dashed{text-decoration-line:underline;text-decoration-style:dashed}.underline-dotted{text-decoration-line:underline;text-decoration-style:dotted}.underline-double{text-decoration-line:underline;text-decoration-style:double}.underline-solid{text-decoration-line:underline;text-decoration-style:solid}.underline-wavy{text-decoration-line:underline;text-decoration-style:wavy}.underline-thickness-1{text-decoration-line:underline;text-decoration-thickness:1px}.underline-thickness-2{text-decoration-line:underline;text-decoration-thickness:2px}.underline-thickness-4{text-decoration-line:underline;text-decoration-thickness:4px}.underline-thickness-20{text-decoration-line:underline;text-decoration-thickness:20px}.underline-thickness-auto{text-decoration-line:underline;text-decoration-thickness:auto}.underline-thickness-from-font{text-decoration-line:underline;text-decoration-thickness:from-font}.-underline-offset-1{text-underline-offset:calc(.05em*-1);text-decoration-line:underline}.-underline-offset-2{text-underline-offset:calc(.1em*-1);text-decoration-line:underline}.-underline-offset-20{text-underline-offset:calc(1em*-1);text-decoration-line:underline}.underline-offset-1{text-underline-offset:.05em;text-decoration-line:underline}.underline-offset-2{text-underline-offset:.1em;text-decoration-line:underline}.underline-offset-4{text-underline-offset:.2em;text-decoration-line:underline}.underline-offset-20{text-underline-offset:1em;text-decoration-line:underline}.underline-skip-all{-webkit-text-decoration-skip-ink:all;text-decoration-skip-ink:all;text-decoration-line:underline}.underline-skip-auto{-webkit-text-decoration-skip-ink:auto;text-decoration-skip-ink:auto;text-decoration-line:underline}.underline-skip-none{-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none;text-decoration-line:underline}.underline{text-decoration-line:underline}.-underline-offset-1{text-underline-offset:calc(1px*-1)}.-underline-offset-2{text-underline-offset:calc(2px*-1)}.-underline-offset-20{text-underline-offset:calc(20px*-1)}.underline-offset-0{text-underline-offset:0px}.underline-offset-1{text-underline-offset:1px}.underline-offset-2{text-underline-offset:2px}.underline-offset-4{text-underline-offset:4px}.underline-offset-20{text-underline-offset:20px}.antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.subpixel-antialiased{-webkit-font-smoothing:auto;-moz-osx-font-smoothing:auto}.opacity-50{opacity:.5}.grayscale{--tw-grayscale:grayscale(100%);filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.transition{transition-property:color,background-color,border-color,outline-color,text-decoration-color,fill,stroke,--tw-gradient-from,--tw-gradient-via,--tw-gradient-to,opacity,box-shadow,transform,translate,scale,rotate,filter,-webkit-backdrop-filter,backdrop-filter,display,visibility,content-visibility,overlay,pointer-events;transition-timing-function:var(--tw-ease,var(--default-transition-timing-function));transition-duration:var(--tw-duration,var(--default-transition-duration))}.ease-in-out{--tw-ease:var(--ease-in-out);transition-timing-function:var(--ease-in-out)}.content-\[\'\'\]{--tw-content:"";content:var(--tw-content)}.content-\[\'—\'\]{--tw-content:"—";content:var(--tw-content)}.content-\[close-quote\]{--tw-content:close-quote;content:var(--tw-content)}.content-\[open-quote\]{--tw-content:open-quote;content:var(--tw-content)}.background-fill-none:before{content:none}.grid-cols-2.grid-line-x>:nth-child(odd):before,.grid-cols-2.grid-line-xfull>:nth-child(odd):before{--gridline-x-start:0}.grid-cols-2.grid-line-x>:nth-child(2n+2):before,.grid-cols-2.grid-line-xfull>:nth-child(2n+2):before{--gridline-x-end:0}.grid-cols-2[class*=grid-line-y]>:nth-child(n):after{--gridline-y-width:1px}.grid-cols-2[class*=grid-line-y]>:nth-child(2n+2):after{--gridline-y-width:0}.grid-cols-2.grid-line-y>:nth-child(-n+2):after,.grid-cols-2.grid-line-yfull>:nth-child(-n+2):after{--gridline-y-top:0}.grid-cols-2.grid-line-y>:nth-child(odd):nth-last-child(-n+2):after,.grid-cols-2.grid-line-yfull>:nth-child(odd):nth-last-child(-n+2):after{--gridline-y-bottom:0}.grid-cols-2.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-2.grid-line-x>:nth-child(odd):before{--gridline-x-start:0}.grid-cols-2.grid-line-x>:nth-child(2n+2):before{--gridline-x-end:0}.grid-cols-2.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-2.grid-line-x>:nth-child(odd):nth-last-child(-n+2):before,.grid-cols-2.grid-line-x>:nth-child(odd):nth-last-child(-n+2)~:before{--gridline-x-width:0}.grid-cols-3.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-3.grid-line-x>:nth-child(3n+1):before{--gridline-x-start:0}.grid-cols-3.grid-line-x>:nth-child(3n+3):before{--gridline-x-end:0}.grid-cols-3.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-3.grid-line-x>:nth-child(3n+1):nth-last-child(-n+3):before,.grid-cols-3.grid-line-x>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.grid-cols-4.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-4.grid-line-x>:nth-child(4n+1):before{--gridline-x-start:0}.grid-cols-4.grid-line-x>:nth-child(4n+4):before{--gridline-x-end:0}.grid-cols-4.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-4.grid-line-x>:nth-child(4n+1):nth-last-child(-n+4):before,.grid-cols-4.grid-line-x>:nth-child(4n+1):nth-last-child(-n+4)~:before{--gridline-x-width:0}.grid-cols-5.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-5.grid-line-x>:nth-child(5n+1):before{--gridline-x-start:0}.grid-cols-5.grid-line-x>:nth-child(5n+5):before{--gridline-x-end:0}.grid-cols-5.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-5.grid-line-x>:nth-child(5n+1):nth-last-child(-n+5):before,.grid-cols-5.grid-line-x>:nth-child(5n+1):nth-last-child(-n+5)~:before{--gridline-x-width:0}.grid-cols-6.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-6.grid-line-x>:nth-child(6n+1):before{--gridline-x-start:0}.grid-cols-6.grid-line-x>:nth-child(6n+6):before{--gridline-x-end:0}.grid-cols-6.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-6.grid-line-x>:nth-child(6n+1):nth-last-child(-n+6):before,.grid-cols-6.grid-line-x>:nth-child(6n+1):nth-last-child(-n+6)~:before{--gridline-x-width:0}.grid-cols-7.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-7.grid-line-x>:nth-child(7n+1):before{--gridline-x-start:0}.grid-cols-7.grid-line-x>:nth-child(7n+7):before{--gridline-x-end:0}.grid-cols-7.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-7.grid-line-x>:nth-child(7n+1):nth-last-child(-n+7):before,.grid-cols-7.grid-line-x>:nth-child(7n+1):nth-last-child(-n+7)~:before{--gridline-x-width:0}.grid-cols-8.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-8.grid-line-x>:nth-child(8n+1):before{--gridline-x-start:0}.grid-cols-8.grid-line-x>:nth-child(8n+8):before{--gridline-x-end:0}.grid-cols-8.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-8.grid-line-x>:nth-child(8n+1):nth-last-child(-n+8):before,.grid-cols-8.grid-line-x>:nth-child(8n+1):nth-last-child(-n+8)~:before{--gridline-x-width:0}.grid-cols-9.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-9.grid-line-x>:nth-child(9n+1):before{--gridline-x-start:0}.grid-cols-9.grid-line-x>:nth-child(9n+9):before{--gridline-x-end:0}.grid-cols-9.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-9.grid-line-x>:nth-child(9n+1):nth-last-child(-n+9):before,.grid-cols-9.grid-line-x>:nth-child(9n+1):nth-last-child(-n+9)~:before{--gridline-x-width:0}.grid-cols-10.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-10.grid-line-x>:nth-child(10n+1):before{--gridline-x-start:0}.grid-cols-10.grid-line-x>:nth-child(10n+10):before{--gridline-x-end:0}.grid-cols-10.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-10.grid-line-x>:nth-child(10n+1):nth-last-child(-n+10):before,.grid-cols-10.grid-line-x>:nth-child(10n+1):nth-last-child(-n+10)~:before{--gridline-x-width:0}.grid-cols-11.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-11.grid-line-x>:nth-child(11n+1):before{--gridline-x-start:0}.grid-cols-11.grid-line-x>:nth-child(11n+11):before{--gridline-x-end:0}.grid-cols-11.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-11.grid-line-x>:nth-child(11n+1):nth-last-child(-n+11):before,.grid-cols-11.grid-line-x>:nth-child(11n+1):nth-last-child(-n+11)~:before{--gridline-x-width:0}.grid-cols-12.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-12.grid-line-x>:nth-child(12n+1):before{--gridline-x-start:0}.grid-cols-12.grid-line-x>:nth-child(12n+12):before{--gridline-x-end:0}.grid-cols-12.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-12.grid-line-x>:nth-child(12n+1):nth-last-child(-n+12):before,.grid-cols-12.grid-line-x>:nth-child(12n+1):nth-last-child(-n+12)~:before{--gridline-x-width:0}.grid-cols-2.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-2.grid-line-xfull>:nth-child(odd):before{--gridline-x-start:0}.grid-cols-2.grid-line-xfull>:nth-child(2n+2):before{--gridline-x-end:0}.grid-cols-2.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-2.grid-line-xfull>:nth-child(odd):nth-last-child(-n+2):before,.grid-cols-2.grid-line-xfull>:nth-child(odd):nth-last-child(-n+2)~:before{--gridline-x-width:0}.grid-cols-3.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-3.grid-line-xfull>:nth-child(3n+1):before{--gridline-x-start:0}.grid-cols-3.grid-line-xfull>:nth-child(3n+3):before{--gridline-x-end:0}.grid-cols-3.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-3.grid-line-xfull>:nth-child(3n+1):nth-last-child(-n+3):before,.grid-cols-3.grid-line-xfull>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.grid-cols-4.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-4.grid-line-xfull>:nth-child(4n+1):before{--gridline-x-start:0}.grid-cols-4.grid-line-xfull>:nth-child(4n+4):before{--gridline-x-end:0}.grid-cols-4.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-4.grid-line-xfull>:nth-child(4n+1):nth-last-child(-n+4):before,.grid-cols-4.grid-line-xfull>:nth-child(4n+1):nth-last-child(-n+4)~:before{--gridline-x-width:0}.grid-cols-5.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-5.grid-line-xfull>:nth-child(5n+1):before{--gridline-x-start:0}.grid-cols-5.grid-line-xfull>:nth-child(5n+5):before{--gridline-x-end:0}.grid-cols-5.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-5.grid-line-xfull>:nth-child(5n+1):nth-last-child(-n+5):before,.grid-cols-5.grid-line-xfull>:nth-child(5n+1):nth-last-child(-n+5)~:before{--gridline-x-width:0}.grid-cols-6.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-6.grid-line-xfull>:nth-child(6n+1):before{--gridline-x-start:0}.grid-cols-6.grid-line-xfull>:nth-child(6n+6):before{--gridline-x-end:0}.grid-cols-6.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-6.grid-line-xfull>:nth-child(6n+1):nth-last-child(-n+6):before,.grid-cols-6.grid-line-xfull>:nth-child(6n+1):nth-last-child(-n+6)~:before{--gridline-x-width:0}.grid-cols-7.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-7.grid-line-xfull>:nth-child(7n+1):before{--gridline-x-start:0}.grid-cols-7.grid-line-xfull>:nth-child(7n+7):before{--gridline-x-end:0}.grid-cols-7.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-7.grid-line-xfull>:nth-child(7n+1):nth-last-child(-n+7):before,.grid-cols-7.grid-line-xfull>:nth-child(7n+1):nth-last-child(-n+7)~:before{--gridline-x-width:0}.grid-cols-8.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-8.grid-line-xfull>:nth-child(8n+1):before{--gridline-x-start:0}.grid-cols-8.grid-line-xfull>:nth-child(8n+8):before{--gridline-x-end:0}.grid-cols-8.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-8.grid-line-xfull>:nth-child(8n+1):nth-last-child(-n+8):before,.grid-cols-8.grid-line-xfull>:nth-child(8n+1):nth-last-child(-n+8)~:before{--gridline-x-width:0}.grid-cols-9.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-9.grid-line-xfull>:nth-child(9n+1):before{--gridline-x-start:0}.grid-cols-9.grid-line-xfull>:nth-child(9n+9):before{--gridline-x-end:0}.grid-cols-9.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-9.grid-line-xfull>:nth-child(9n+1):nth-last-child(-n+9):before,.grid-cols-9.grid-line-xfull>:nth-child(9n+1):nth-last-child(-n+9)~:before{--gridline-x-width:0}.grid-cols-10.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-10.grid-line-xfull>:nth-child(10n+1):before{--gridline-x-start:0}.grid-cols-10.grid-line-xfull>:nth-child(10n+10):before{--gridline-x-end:0}.grid-cols-10.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-10.grid-line-xfull>:nth-child(10n+1):nth-last-child(-n+10):before,.grid-cols-10.grid-line-xfull>:nth-child(10n+1):nth-last-child(-n+10)~:before{--gridline-x-width:0}.grid-cols-11.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-11.grid-line-xfull>:nth-child(11n+1):before{--gridline-x-start:0}.grid-cols-11.grid-line-xfull>:nth-child(11n+11):before{--gridline-x-end:0}.grid-cols-11.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-11.grid-line-xfull>:nth-child(11n+1):nth-last-child(-n+11):before,.grid-cols-11.grid-line-xfull>:nth-child(11n+1):nth-last-child(-n+11)~:before{--gridline-x-width:0}.grid-cols-12.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-12.grid-line-xfull>:nth-child(12n+1):before{--gridline-x-start:0}.grid-cols-12.grid-line-xfull>:nth-child(12n+12):before{--gridline-x-end:0}.grid-cols-12.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-12.grid-line-xfull>:nth-child(12n+1):nth-last-child(-n+12):before,.grid-cols-12.grid-line-xfull>:nth-child(12n+1):nth-last-child(-n+12)~:before{--gridline-x-width:0}.grid-cols-1.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-1.grid-line-x>:nth-child(n+1):before{--gridline-x-end:0}.grid-cols-1.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-1.grid-line-x>:nth-child(n+1):nth-last-child(-n+1):before,.grid-cols-1.grid-line-x>:nth-child(n+1):nth-last-child(-n+1)~:before{--gridline-x-width:0}.grid-cols-1.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.grid-cols-1.grid-line-xfull>:nth-child(n+1):before{--gridline-x-end:0}.grid-cols-1.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-1.grid-line-xfull>:nth-child(n+1):nth-last-child(-n+1):before,.grid-cols-1.grid-line-xfull>:nth-child(n+1):nth-last-child(-n+1)~:before{--gridline-x-width:0}.grid-line-x-24>:before,.grid-line-x-24.grid-line-yfull>:after{--gridline-x-bottom:-24px;--gridline-y-top:-24px;--gridline-y-bottom:-24px}.grid-line-x-40>:before,.grid-line-x-40.grid-line-yfull>:after{--gridline-x-bottom:-40px;--gridline-y-top:-40px;--gridline-y-bottom:-40px}.scrollbar-thin-collapse{--scrollbar-width:6px;--scrollbar-padding:0px;scrollbar-width:thin;scrollbar-width:thin}.scrollbar-thin{--scrollbar-width:10px;--scrollbar-padding:2px;scrollbar-width:thin}.grid-line-xy-primary>:before{--gridline-x-color:var(--color-grey-90)}.grid-line-xy-primary>:after{--gridline-y-color:var(--color-grey-90)}.grid-line-xy-secondary>:before{--gridline-x-color:var(--color-grey-30)}.grid-line-xy-secondary>:after{--gridline-y-color:var(--color-grey-30)}.grid-cols-2.grid-line-y>:nth-child(-n+2):after{--gridline-y-top:0}.grid-cols-2.grid-line-y>:nth-child(odd):nth-last-child(-n+2):after{--gridline-y-bottom:0}.grid-cols-3.grid-line-y>:nth-child(-n+3):after{--gridline-y-top:0}.grid-cols-3.grid-line-y>:nth-child(3n+1):nth-last-child(-n+3):after{--gridline-y-bottom:0}.grid-cols-4.grid-line-y>:nth-child(-n+4):after{--gridline-y-top:0}.grid-cols-4.grid-line-y>:nth-child(4n+1):nth-last-child(-n+4):after{--gridline-y-bottom:0}.grid-cols-5.grid-line-y>:nth-child(-n+5):after{--gridline-y-top:0}.grid-cols-5.grid-line-y>:nth-child(5n+1):nth-last-child(-n+5):after{--gridline-y-bottom:0}.grid-cols-6.grid-line-y>:nth-child(-n+6):after{--gridline-y-top:0}.grid-cols-6.grid-line-y>:nth-child(6n+1):nth-last-child(-n+6):after{--gridline-y-bottom:0}.grid-cols-7.grid-line-y>:nth-child(-n+7):after{--gridline-y-top:0}.grid-cols-7.grid-line-y>:nth-child(7n+1):nth-last-child(-n+7):after{--gridline-y-bottom:0}.grid-cols-8.grid-line-y>:nth-child(-n+8):after{--gridline-y-top:0}.grid-cols-8.grid-line-y>:nth-child(8n+1):nth-last-child(-n+8):after{--gridline-y-bottom:0}.grid-cols-9.grid-line-y>:nth-child(-n+9):after{--gridline-y-top:0}.grid-cols-9.grid-line-y>:nth-child(9n+1):nth-last-child(-n+9):after{--gridline-y-bottom:0}.grid-cols-10.grid-line-y>:nth-child(-n+10):after{--gridline-y-top:0}.grid-cols-10.grid-line-y>:nth-child(10n+1):nth-last-child(-n+10):after{--gridline-y-bottom:0}.grid-cols-11.grid-line-y>:nth-child(-n+11):after{--gridline-y-top:0}.grid-cols-11.grid-line-y>:nth-child(11n+1):nth-last-child(-n+11):after{--gridline-y-bottom:0}.grid-cols-12.grid-line-y>:nth-child(-n+12):after{--gridline-y-top:0}.grid-cols-12.grid-line-y>:nth-child(12n+1):nth-last-child(-n+12):after{--gridline-y-bottom:0}.grid-cols-2.grid-line-yfull>:nth-child(-n+2):after{--gridline-y-top:0}.grid-cols-2.grid-line-yfull>:nth-child(odd):nth-last-child(-n+2):after{--gridline-y-bottom:0}.grid-cols-3.grid-line-yfull>:nth-child(-n+3):after{--gridline-y-top:0}.grid-cols-3.grid-line-yfull>:nth-child(3n+1):nth-last-child(-n+3):after{--gridline-y-bottom:0}.grid-cols-4.grid-line-yfull>:nth-child(-n+4):after{--gridline-y-top:0}.grid-cols-4.grid-line-yfull>:nth-child(4n+1):nth-last-child(-n+4):after{--gridline-y-bottom:0}.grid-cols-5.grid-line-yfull>:nth-child(-n+5):after{--gridline-y-top:0}.grid-cols-5.grid-line-yfull>:nth-child(5n+1):nth-last-child(-n+5):after{--gridline-y-bottom:0}.grid-cols-6.grid-line-yfull>:nth-child(-n+6):after{--gridline-y-top:0}.grid-cols-6.grid-line-yfull>:nth-child(6n+1):nth-last-child(-n+6):after{--gridline-y-bottom:0}.grid-cols-7.grid-line-yfull>:nth-child(-n+7):after{--gridline-y-top:0}.grid-cols-7.grid-line-yfull>:nth-child(7n+1):nth-last-child(-n+7):after{--gridline-y-bottom:0}.grid-cols-8.grid-line-yfull>:nth-child(-n+8):after{--gridline-y-top:0}.grid-cols-8.grid-line-yfull>:nth-child(8n+1):nth-last-child(-n+8):after{--gridline-y-bottom:0}.grid-cols-9.grid-line-yfull>:nth-child(-n+9):after{--gridline-y-top:0}.grid-cols-9.grid-line-yfull>:nth-child(9n+1):nth-last-child(-n+9):after{--gridline-y-bottom:0}.grid-cols-10.grid-line-yfull>:nth-child(-n+10):after{--gridline-y-top:0}.grid-cols-10.grid-line-yfull>:nth-child(10n+1):nth-last-child(-n+10):after{--gridline-y-bottom:0}.grid-cols-11.grid-line-yfull>:nth-child(-n+11):after{--gridline-y-top:0}.grid-cols-11.grid-line-yfull>:nth-child(11n+1):nth-last-child(-n+11):after{--gridline-y-bottom:0}.grid-cols-12.grid-line-yfull>:nth-child(-n+12):after{--gridline-y-top:0}.grid-cols-12.grid-line-yfull>:nth-child(12n+1):nth-last-child(-n+12):after{--gridline-y-bottom:0}.keyline-0{--keyline-l-color:transparent;--keyline-r-color:transparent}.scrollbar-track-bg-column{--scrollbar-bg:var(--color-blue-05);--scrollbar-border:var(--scrollbar-bg)}.scrollbar-track-grey-15{--scrollbar-bg:var(--color-grey-15);--scrollbar-border:var(--scrollbar-bg)}.scrollbar-track-primary{--scrollbar-bg:var(--color-blue-06);--scrollbar-border:var(--scrollbar-bg)}.w-cols-1>*{--container-grid-columns:1;--cols-container:0}.w-cols-2>*{--container-grid-columns:2;--cols-container:0}.w-cols-3>*{--container-grid-columns:3;--cols-container:0}.w-cols-4>*{--container-grid-columns:4;--cols-container:0}.w-cols-5>*{--container-grid-columns:5;--cols-container:0}.w-cols-6>*{--container-grid-columns:6;--cols-container:0}.w-cols-7>*{--container-grid-columns:7;--cols-container:0}.w-cols-8>*{--container-grid-columns:8;--cols-container:0}.w-cols-9>*{--container-grid-columns:9;--cols-container:0}.w-cols-10>*{--container-grid-columns:10;--cols-container:0}.w-cols-11>*{--container-grid-columns:11;--cols-container:0}.w-cols-12>*{--container-grid-columns:12;--cols-container:0}.w-cols-vw-1>*{--container-grid-columns:1;--cols-container:0}.w-cols-vw-2>*{--container-grid-columns:2;--cols-container:0}.w-cols-vw-3>*{--container-grid-columns:3;--cols-container:0}.w-cols-vw-4>*{--container-grid-columns:4;--cols-container:0}.w-cols-vw-5>*{--container-grid-columns:5;--cols-container:0}.w-cols-vw-6>*{--container-grid-columns:6;--cols-container:0}.w-cols-vw-7>*{--container-grid-columns:7;--cols-container:0}.w-cols-vw-8>*{--container-grid-columns:8;--cols-container:0}.grid-line-x-primary>:before{--gridline-x-color:var(--color-grey-90)}.grid-line-x-secondary>:before{--gridline-x-color:var(--color-grey-30)}.grid-line-y-primary>:after{--gridline-y-color:var(--color-grey-90)}.grid-line-y-quaternary>:after{--gridline-y-color:var(--color-blue-05)}.grid-line-y-tertiary>:after{--gridline-y-color:var(--color-grey-54)}.ratio-1x1{--ratio:100%}.ratio-16x9{--ratio:56.25%}.scrollbar-thumb-bg-column-alt{--scrollbar-fg:var(--color-blue-04)}.scrollbar-thumb-primary{--scrollbar-fg:var(--color-blue-03)}.scrollbar-thumb-red-01{--scrollbar-fg:var(--color-red-01)}.stroke-full-2{--stroke-full-thickness:2px}.stroke-full-4{--stroke-full-thickness:4px}.stroke-full-10{--stroke-full-thickness:10px}.stroke-full-dashed{--stroke-full-style:dashed}.stroke-full-dotted{--stroke-full-style:dotted}.stroke-full-primary{--stroke-full-color:var(--color-grey-90)}.stroke-full-secondary{--stroke-full-color:var(--color-grey-30)}.stroke-full-tertiary{--stroke-full-color:var(--color-grey-54)}.marker\:content-\[\'⛄️\'\] ::marker{--tw-content:"⛄️";content:var(--tw-content)}.marker\:content-\[\'⛄️\'\]::marker{--tw-content:"⛄️";content:var(--tw-content)}.marker\:content-\[\'⛄️\'\] ::-webkit-details-marker{--tw-content:"⛄️";content:var(--tw-content)}.marker\:content-\[\'⛄️\'\]::-webkit-details-marker{--tw-content:"⛄️";content:var(--tw-content)}@media (hover:hover){.hover\:underline-border-primary:hover{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-90);-webkit-text-decoration-color:var(--color-grey-90);text-decoration-color:var(--color-grey-90)}.hover\:opacity-100:hover{opacity:1}}.focus\:underline-border-secondary:focus{text-decoration-line:underline;-webkit-text-decoration-color:var(--color-grey-30);-webkit-text-decoration-color:var(--color-grey-30);text-decoration-color:var(--color-grey-30)}.data-\[header-sticky\=true\]\:top-\[var\(--offset\)\][data-header-sticky=true]{top:var(--offset)}.data-\[header-sticky\=true\]\:data-\[header-reveal\=true\]\:top-0[data-header-sticky=true][data-header-reveal=true]{top:calc(var(--spacing)*0)}@media (min-width:544px){.sm\:mt-0{margin-top:calc(var(--spacing)*0)}.sm\:mr-20{margin-right:calc(var(--spacing)*20)}.sm\:mr-auto{margin-right:auto}.sm\:flex{display:flex}.sm\:w-cols-3{width:calc(((3/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (3/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.sm\:flex-row{flex-direction:row}.sm\:w-cols-3>*{--container-grid-columns:3;--cols-container:0}}@media (min-width:650px){.md\:grid-line-y>*{position:relative}.md\:grid-line-y>:before,.md\:grid-line-y>:after{z-index:0;pointer-events:none;position:absolute}.md\:grid-line-y>:after{content:"";border-inline-start:0 solid #0000;border-inline-end:var(--gridline-y-width,0)solid var(--gridline-y-color,transparent);inset-inline-start:0;inset-inline-end:calc(var(--inner-gutter)/-2);top:0;bottom:0}.md\:keyline-l-primary{--keyline-l-color:var(--color-grey-90);--keyline-r-color:transparent;position:relative}.md\:keyline-l-primary:before{content:"";z-index:0;border-left:1px solid var(--keyline-l-color,transparent);border-right:1px solid var(--keyline-r-color,transparent);pointer-events:none;inset-inline-start:calc(var(--inner-gutter)/-2 - 1px);inset-inline-end:calc(var(--inner-gutter)/-2);position:absolute;top:0;bottom:0}.md\:keyline-l-secondary{--keyline-l-color:var(--color-grey-30);--keyline-r-color:transparent;position:relative}.md\:keyline-l-secondary:before{content:"";z-index:0;border-left:1px solid var(--keyline-l-color,transparent);border-right:1px solid var(--keyline-r-color,transparent);pointer-events:none;inset-inline-start:calc(var(--inner-gutter)/-2 - 1px);inset-inline-end:calc(var(--inner-gutter)/-2);position:absolute;top:0;bottom:0}.md\:background-fill-accent{--background-fill-bg:var(--color-blue-03);position:relative}.md\:background-fill-accent:before{content:"";z-index:-1;background-color:var(--background-fill-bg,inherit);pointer-events:none;inset-inline-start:50%;width:100vw;margin-inline-start:-50vw;position:absolute;top:0;bottom:0}.md\:grid-col-span-2{--container-grid-columns:2;grid-column:span 2/span 2}.md\:grid-col-span-4{--container-grid-columns:4;grid-column:span 4/span 4}.md\:mt-60{margin-top:calc(var(--spacing)*60)}.md\:full-bleed-scroller-reset{display:unset;flex-flow:unset;flex-wrap:unset;overflow-x:unset}.md\:full-bleed-scroller-reset:before,.md\:full-bleed-scroller-reset:after{content:none;flex:unset;width:unset}.md\:grid{display:grid}.md\:w-auto{width:auto}.md\:w-cols-1\/2{width:calc(50% - (var(--inner-gutter)*max(.5,var(--cols-container,0))))}.md\:w-cols-6{width:calc(((6/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (6/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.md\:gap-gutter{grid-gap:var(--inner-gutter);gap:var(--inner-gutter)}.md\:gap-x-gutter{grid-column-gap:var(--inner-gutter);column-gap:var(--inner-gutter)}.md\:gap-y-64{row-gap:calc(var(--spacing)*64)}.md\:border-t-0{border-top-style:var(--tw-border-style);border-top-width:0}.md\:bg-accent{background-color:var(--color-blue-03)}.md\:px-40{padding-inline:calc(var(--spacing)*40)}.md\:pt-0{padding-top:calc(var(--spacing)*0)}.md\:pt-80{padding-top:calc(var(--spacing)*80)}.md\:f-code{font-family:var(--f-code-font-family);font-weight:var(--f-code-font-weight);font-size:var(--f-code-font-size);line-height:var(--f-code-line-height);letter-spacing:var(--f-code-letter-spacing);-moz-osx-font-smoothing:var(--f-code--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-code--webkit-font-smoothing)}.md\:f-code b,.md\:f-code strong{font-weight:var(--f-code---bold-weight,bold)}.md\:grid-cols-2.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.md\:grid-cols-2.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.md\:grid-cols-2.grid-line-x>:nth-child(odd):before,.md\:grid-cols-2.grid-line-xfull>:nth-child(odd):before{--gridline-x-start:0}.md\:grid-cols-2.grid-line-x>:nth-child(2n+2):before,.md\:grid-cols-2.grid-line-xfull>:nth-child(2n+2):before{--gridline-x-end:0}.md\:grid-cols-2.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.md\:grid-cols-2.grid-line-x>:nth-child(odd):nth-last-child(-n+2):before,.md\:grid-cols-2.grid-line-x>:nth-child(odd):nth-last-child(-n+2)~:before{--gridline-x-width:0}.md\:grid-cols-2.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.md\:grid-cols-2.grid-line-xfull>:nth-child(odd):nth-last-child(-n+2):before,.md\:grid-cols-2.grid-line-xfull>:nth-child(odd):nth-last-child(-n+2)~:before{--gridline-x-width:0}.md\:grid-cols-2[class*=grid-line-y]>:nth-child(n):after{--gridline-y-width:1px}.md\:grid-cols-2[class*=grid-line-y]>:nth-child(2n+2):after{--gridline-y-width:0}.md\:grid-cols-2.grid-line-y>:nth-child(-n+2):after,.md\:grid-cols-2.grid-line-yfull>:nth-child(-n+2):after{--gridline-y-top:0}.md\:grid-cols-2.grid-line-y>:nth-child(odd):nth-last-child(-n+2):after,.md\:grid-cols-2.grid-line-yfull>:nth-child(odd):nth-last-child(-n+2):after{--gridline-y-bottom:0}.md\:grid-cols-3.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.md\:grid-cols-3.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.md\:grid-cols-3.grid-line-x>:nth-child(3n+1):before,.md\:grid-cols-3.grid-line-xfull>:nth-child(3n+1):before{--gridline-x-start:0}.md\:grid-cols-3.grid-line-x>:nth-child(3n+3):before,.md\:grid-cols-3.grid-line-xfull>:nth-child(3n+3):before{--gridline-x-end:0}.md\:grid-cols-3.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.md\:grid-cols-3.grid-line-x>:nth-child(3n+1):nth-last-child(-n+3):before,.md\:grid-cols-3.grid-line-x>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.md\:grid-cols-3.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.md\:grid-cols-3.grid-line-xfull>:nth-child(3n+1):nth-last-child(-n+3):before,.md\:grid-cols-3.grid-line-xfull>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.md\:grid-cols-3[class*=grid-line-y]>:nth-child(n):after{--gridline-y-width:1px}.md\:grid-cols-3[class*=grid-line-y]>:nth-child(3n+3):after{--gridline-y-width:0}.md\:grid-cols-3.grid-line-y>:nth-child(-n+3):after,.md\:grid-cols-3.grid-line-yfull>:nth-child(-n+3):after{--gridline-y-top:0}.md\:grid-cols-3.grid-line-y>:nth-child(3n+1):nth-last-child(-n+3):after,.md\:grid-cols-3.grid-line-yfull>:nth-child(3n+1):nth-last-child(-n+3):after{--gridline-y-bottom:0}.md\:grid-line-x-32>:before,.md\:grid-line-x-32.grid-line-yfull>:after{--gridline-x-bottom:-32px;--gridline-y-top:-32px;--gridline-y-bottom:-32px}.grid-cols-2.md\:grid-line-y>:nth-child(-n+2):after{--gridline-y-top:0}.grid-cols-2.md\:grid-line-y>:nth-child(odd):nth-last-child(-n+2):after{--gridline-y-bottom:0}.grid-cols-3.md\:grid-line-y>:nth-child(-n+3):after{--gridline-y-top:0}.grid-cols-3.md\:grid-line-y>:nth-child(3n+1):nth-last-child(-n+3):after{--gridline-y-bottom:0}.grid-cols-4.md\:grid-line-y>:nth-child(-n+4):after{--gridline-y-top:0}.grid-cols-4.md\:grid-line-y>:nth-child(4n+1):nth-last-child(-n+4):after{--gridline-y-bottom:0}.grid-cols-5.md\:grid-line-y>:nth-child(-n+5):after{--gridline-y-top:0}.grid-cols-5.md\:grid-line-y>:nth-child(5n+1):nth-last-child(-n+5):after{--gridline-y-bottom:0}.grid-cols-6.md\:grid-line-y>:nth-child(-n+6):after{--gridline-y-top:0}.grid-cols-6.md\:grid-line-y>:nth-child(6n+1):nth-last-child(-n+6):after{--gridline-y-bottom:0}.grid-cols-7.md\:grid-line-y>:nth-child(-n+7):after{--gridline-y-top:0}.grid-cols-7.md\:grid-line-y>:nth-child(7n+1):nth-last-child(-n+7):after{--gridline-y-bottom:0}.grid-cols-8.md\:grid-line-y>:nth-child(-n+8):after{--gridline-y-top:0}.grid-cols-8.md\:grid-line-y>:nth-child(8n+1):nth-last-child(-n+8):after{--gridline-y-bottom:0}.grid-cols-9.md\:grid-line-y>:nth-child(-n+9):after{--gridline-y-top:0}.grid-cols-9.md\:grid-line-y>:nth-child(9n+1):nth-last-child(-n+9):after{--gridline-y-bottom:0}.grid-cols-10.md\:grid-line-y>:nth-child(-n+10):after{--gridline-y-top:0}.grid-cols-10.md\:grid-line-y>:nth-child(10n+1):nth-last-child(-n+10):after{--gridline-y-bottom:0}.grid-cols-11.md\:grid-line-y>:nth-child(-n+11):after{--gridline-y-top:0}.grid-cols-11.md\:grid-line-y>:nth-child(11n+1):nth-last-child(-n+11):after{--gridline-y-bottom:0}.grid-cols-12.md\:grid-line-y>:nth-child(-n+12):after{--gridline-y-top:0}.grid-cols-12.md\:grid-line-y>:nth-child(12n+1):nth-last-child(-n+12):after{--gridline-y-bottom:0}.md\:keyline-0,.md\:keyline-l-0,.md\:keyline-r-0{--keyline-l-color:transparent;--keyline-r-color:transparent}.md\:w-cols-6>*{--container-grid-columns:6;--cols-container:0}.md\:grid-line-x-primary>:before{--gridline-x-color:var(--color-grey-90)}.md\:grid-line-x-quaternary>:before{--gridline-x-color:var(--color-blue-05)}.md\:grid-line-x-tertiary>:before{--gridline-x-color:var(--color-grey-54)}.md\:grid-line-y-primary>:after{--gridline-y-color:var(--color-grey-90)}.md\:ratio-16x9{--ratio:56.25%}.md\:before\:hidden:before,.md\:after\:hidden:after{content:var(--tw-content);display:none}}@media (min-width:990px){.lg\:keyline-l-secondary{--keyline-l-color:var(--color-grey-30);--keyline-r-color:transparent;position:relative}.lg\:keyline-l-secondary:before{content:"";z-index:0;border-left:1px solid var(--keyline-l-color,transparent);border-right:1px solid var(--keyline-r-color,transparent);pointer-events:none;inset-inline-start:calc(var(--inner-gutter)/-2 - 1px);inset-inline-end:calc(var(--inner-gutter)/-2);position:absolute;top:0;bottom:0}.lg\:keyline-l-tertiary{--keyline-l-color:var(--color-grey-54);--keyline-r-color:transparent;position:relative}.lg\:keyline-l-tertiary:before{content:"";z-index:0;border-left:1px solid var(--keyline-l-color,transparent);border-right:1px solid var(--keyline-r-color,transparent);pointer-events:none;inset-inline-start:calc(var(--inner-gutter)/-2 - 1px);inset-inline-end:calc(var(--inner-gutter)/-2);position:absolute;top:0;bottom:0}.lg\:grid-line-x-0>*{position:relative}.lg\:grid-line-x-0>:before,.lg\:grid-line-x-0>:after{z-index:0;pointer-events:none;position:absolute}.lg\:grid-line-x-0>:before{content:none}.lg\:grid-line-y-0>*{position:relative}.lg\:grid-line-y-0>:before,.lg\:grid-line-y-0>:after{z-index:0;pointer-events:none;position:absolute}.lg\:grid-line-y-0>:after{content:none}.lg\:container[class]{width:calc(var(--container-width,100%) - (2*var(--breakout-container-outer-gutter,var(--container-outer-gutter,var(--outer-gutter,0)))));margin-left:auto;margin-right:auto}.lg\:container[class]>*{--container-outer-gutter:0;--breakout-container-outer-gutter:0}.lg\:container[class]>.breakout[class],.lg\:breakout[class],.container[class]>.lg\:breakout[class]{--breakout-outer-gutter:max(var(--outer-gutter),calc((100% - var(--container-width,100%))/2));--breakout-container-outer-gutter:var(--outer-gutter);width:calc(100vw - var(--scrollbar-visible-width,0px));margin-inline-start:calc((100vw - var(--scrollbar-visible-width,0px))/-2);position:relative;inset-inline-start:50%}.lg\:breakout[class].px-outer-gutter,.lg\:breakout[class]>.px-outer-gutter{padding-inline-start:var(--breakout-outer-gutter);padding-inline-end:var(--breakout-outer-gutter)}.lg\:breakout[class].pr-outer-gutter,.lg\:breakout[class]>.pr-outer-gutter{padding-inline-end:var(--breakout-outer-gutter)}.lg\:breakout[class].pl-outer-gutter,.lg\:breakout[class]>.pl-outer-gutter{padding-inline-start:var(--breakout-outer-gutter)}.lg\:breakout[class]>.w-outer-gutter{width:var(--breakout-outer-gutter)}.lg\:ratio-free:before,.lg\:ratio-free:after{content:unset}.lg\:ratio-free>[class*=ratio-content]{width:auto;height:auto;position:static;inset:auto}.lg\:ratio-free>[class*=ratio-content][class*=w-full]{width:100%}.lg\:ratio-free>[class*=ratio-content][class*=h-auto]{height:auto}.lg\:grid-col-span-4{--container-grid-columns:4;grid-column:span 4/span 4}.lg\:grid-col-span-6{--container-grid-columns:6;grid-column:span 6/span 6}.lg\:container{width:100%}@media (min-width:0){.lg\:container{max-width:0}}@media (min-width:544px){.lg\:container{max-width:544px}}@media (min-width:650px){.lg\:container{max-width:650px}}@media (min-width:990px){.lg\:container{max-width:990px}}@media (min-width:1300px){.lg\:container{max-width:1300px}}@media (min-width:1520px){.lg\:container{max-width:1520px}}.lg\:mx-cols-1{margin-inline:calc(((((1/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (1/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.lg\:mx-cols-3{margin-inline:calc(((((3/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (3/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter)))) + var(--inner-gutter)))}.lg\:mt-outer-1{margin-top:var(--spacing-outer-1)}.lg\:w-cols-1{width:calc(((1/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (1/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.lg\:w-cols-2\/3{width:calc(66.666% - (var(--inner-gutter)*max(.333,var(--cols-container,0))))}.lg\:w-cols-3{width:calc(((3/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (3/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.lg\:w-cols-10{width:calc(((10/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (10/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.lg\:w-cols-12{width:calc(((12/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (12/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.lg\:container{max-width:100%}.lg\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.lg\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.lg\:gap-x-0{column-gap:calc(var(--spacing)*0)}.lg\:pt-100{padding-top:calc(var(--spacing)*100)}.lg\:f-code{font-family:var(--f-code-font-family);font-weight:var(--f-code-font-weight);font-size:var(--f-code-font-size);line-height:var(--f-code-line-height);letter-spacing:var(--f-code-letter-spacing);-moz-osx-font-smoothing:var(--f-code--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-code--webkit-font-smoothing)}.lg\:f-code b,.lg\:f-code strong{font-weight:var(--f-code---bold-weight,bold)}.lg\:f-h1{font-family:var(--f-h1-font-family);font-weight:var(--f-h1-font-weight);font-size:var(--f-h1-font-size);line-height:var(--f-h1-line-height);letter-spacing:var(--f-h1-letter-spacing);-moz-osx-font-smoothing:var(--f-h1--moz-osx-font-smoothing);-webkit-font-smoothing:var(--f-h1--webkit-font-smoothing)}.lg\:f-h1 b,.lg\:f-h1 strong{font-weight:var(--f-h1---bold-weight,bold)}.lg\:underline-thickness-8{text-decoration-line:underline;text-decoration-thickness:8px}.lg\:background-fill-none:before{content:none}.lg\:grid-cols-3.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.lg\:grid-cols-3.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.lg\:grid-cols-3.grid-line-x>:nth-child(3n+1):before,.lg\:grid-cols-3.grid-line-xfull>:nth-child(3n+1):before{--gridline-x-start:0}.lg\:grid-cols-3.grid-line-x>:nth-child(3n+3):before,.lg\:grid-cols-3.grid-line-xfull>:nth-child(3n+3):before{--gridline-x-end:0}.lg\:grid-cols-3.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.lg\:grid-cols-3.grid-line-x>:nth-child(3n+1):nth-last-child(-n+3):before,.lg\:grid-cols-3.grid-line-x>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.lg\:grid-cols-3.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.lg\:grid-cols-3.grid-line-xfull>:nth-child(3n+1):nth-last-child(-n+3):before,.lg\:grid-cols-3.grid-line-xfull>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.lg\:grid-cols-3[class*=grid-line-y]>:nth-child(n):after{--gridline-y-width:1px}.lg\:grid-cols-3[class*=grid-line-y]>:nth-child(3n+3):after{--gridline-y-width:0}.lg\:grid-cols-3.grid-line-y>:nth-child(-n+3):after,.lg\:grid-cols-3.grid-line-yfull>:nth-child(-n+3):after{--gridline-y-top:0}.lg\:grid-cols-3.grid-line-y>:nth-child(3n+1):nth-last-child(-n+3):after,.lg\:grid-cols-3.grid-line-yfull>:nth-child(3n+1):nth-last-child(-n+3):after{--gridline-y-bottom:0}.lg\:grid-cols-4.grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.lg\:grid-cols-4.grid-line-xfull>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:calc(var(--inner-gutter)/-2);--gridline-x-end:calc(var(--inner-gutter)/-2)}.lg\:grid-cols-4.grid-line-x>:nth-child(4n+1):before,.lg\:grid-cols-4.grid-line-xfull>:nth-child(4n+1):before{--gridline-x-start:0}.lg\:grid-cols-4.grid-line-x>:nth-child(4n+4):before,.lg\:grid-cols-4.grid-line-xfull>:nth-child(4n+4):before{--gridline-x-end:0}.lg\:grid-cols-4.grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.lg\:grid-cols-4.grid-line-x>:nth-child(4n+1):nth-last-child(-n+4):before,.lg\:grid-cols-4.grid-line-x>:nth-child(4n+1):nth-last-child(-n+4)~:before{--gridline-x-width:0}.lg\:grid-cols-4.grid-line-xfull>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.lg\:grid-cols-4.grid-line-xfull>:nth-child(4n+1):nth-last-child(-n+4):before,.lg\:grid-cols-4.grid-line-xfull>:nth-child(4n+1):nth-last-child(-n+4)~:before{--gridline-x-width:0}.lg\:grid-cols-4[class*=grid-line-y]>:nth-child(n):after{--gridline-y-width:1px}.lg\:grid-cols-4[class*=grid-line-y]>:nth-child(4n+4):after{--gridline-y-width:0}.lg\:grid-cols-4.grid-line-y>:nth-child(-n+4):after,.lg\:grid-cols-4.grid-line-yfull>:nth-child(-n+4):after{--gridline-y-top:0}.lg\:grid-cols-4.grid-line-y>:nth-child(4n+1):nth-last-child(-n+4):after,.lg\:grid-cols-4.grid-line-yfull>:nth-child(4n+1):nth-last-child(-n+4):after{--gridline-y-bottom:0}.lg\:keyline-l-0{--keyline-l-color:transparent;--keyline-r-color:transparent}.lg\:w-cols-1>*{--container-grid-columns:1;--cols-container:0}.lg\:w-cols-3>*{--container-grid-columns:3;--cols-container:0}.lg\:w-cols-10>*{--container-grid-columns:10;--cols-container:0}.lg\:w-cols-12>*{--container-grid-columns:12;--cols-container:0}.lg\:grid-line-y-secondary>:after{--gridline-y-color:var(--color-grey-30)}}@media (min-width:1300px){.xl\:grid-line-x>*{position:relative}.xl\:grid-line-x>:before,.xl\:grid-line-x>:after{z-index:0;pointer-events:none;position:absolute}.xl\:grid-line-x>:before{content:"";inset-inline-start:var(--gridline-x-start,0);inset-inline-end:var(--gridline-x-end,0);top:0;bottom:var(--gridline-x-bottom,calc(var(--inner-gutter)/-2));border-top:0 solid #0000;border-bottom:var(--gridline-x-width,0)solid var(--gridline-x-color,transparent)}.grid-line-yfull.xl\:grid-line-x>:after{inset-inline-start:0;inset-inline-end:calc(var(--inner-gutter)/-2);top:var(--gridline-y-top,calc(var(--inner-gutter)/-2));bottom:var(--gridline-y-bottom,calc(var(--inner-gutter)/-2));border-inline-start:0 solid #0000;border-inline-end:var(--gridline-y-width,0)solid var(--gridline-y-color,transparent)}.xl\:w-cols-1\/2{width:calc(50% - (var(--inner-gutter)*max(.5,var(--cols-container,0))))}.xl\:w-cols-8{width:calc(((8/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (8/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.xl\:gap-x-gutter{grid-column-gap:var(--inner-gutter);column-gap:var(--inner-gutter)}.grid-cols-2.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-2.xl\:grid-line-x>:nth-child(odd):before{--gridline-x-start:0}.grid-cols-2.xl\:grid-line-x>:nth-child(2n+2):before{--gridline-x-end:0}.grid-cols-2.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-2.xl\:grid-line-x>:nth-child(odd):nth-last-child(-n+2):before,.grid-cols-2.xl\:grid-line-x>:nth-child(odd):nth-last-child(-n+2)~:before{--gridline-x-width:0}.grid-cols-3.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-3.xl\:grid-line-x>:nth-child(3n+1):before{--gridline-x-start:0}.grid-cols-3.xl\:grid-line-x>:nth-child(3n+3):before{--gridline-x-end:0}.grid-cols-3.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-3.xl\:grid-line-x>:nth-child(3n+1):nth-last-child(-n+3):before,.grid-cols-3.xl\:grid-line-x>:nth-child(3n+1):nth-last-child(-n+3)~:before{--gridline-x-width:0}.grid-cols-4.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-4.xl\:grid-line-x>:nth-child(4n+1):before{--gridline-x-start:0}.grid-cols-4.xl\:grid-line-x>:nth-child(4n+4):before{--gridline-x-end:0}.grid-cols-4.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-4.xl\:grid-line-x>:nth-child(4n+1):nth-last-child(-n+4):before,.grid-cols-4.xl\:grid-line-x>:nth-child(4n+1):nth-last-child(-n+4)~:before{--gridline-x-width:0}.grid-cols-5.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-5.xl\:grid-line-x>:nth-child(5n+1):before{--gridline-x-start:0}.grid-cols-5.xl\:grid-line-x>:nth-child(5n+5):before{--gridline-x-end:0}.grid-cols-5.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-5.xl\:grid-line-x>:nth-child(5n+1):nth-last-child(-n+5):before,.grid-cols-5.xl\:grid-line-x>:nth-child(5n+1):nth-last-child(-n+5)~:before{--gridline-x-width:0}.grid-cols-6.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-6.xl\:grid-line-x>:nth-child(6n+1):before{--gridline-x-start:0}.grid-cols-6.xl\:grid-line-x>:nth-child(6n+6):before{--gridline-x-end:0}.grid-cols-6.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-6.xl\:grid-line-x>:nth-child(6n+1):nth-last-child(-n+6):before,.grid-cols-6.xl\:grid-line-x>:nth-child(6n+1):nth-last-child(-n+6)~:before{--gridline-x-width:0}.grid-cols-7.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-7.xl\:grid-line-x>:nth-child(7n+1):before{--gridline-x-start:0}.grid-cols-7.xl\:grid-line-x>:nth-child(7n+7):before{--gridline-x-end:0}.grid-cols-7.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-7.xl\:grid-line-x>:nth-child(7n+1):nth-last-child(-n+7):before,.grid-cols-7.xl\:grid-line-x>:nth-child(7n+1):nth-last-child(-n+7)~:before{--gridline-x-width:0}.grid-cols-8.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-8.xl\:grid-line-x>:nth-child(8n+1):before{--gridline-x-start:0}.grid-cols-8.xl\:grid-line-x>:nth-child(8n+8):before{--gridline-x-end:0}.grid-cols-8.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-8.xl\:grid-line-x>:nth-child(8n+1):nth-last-child(-n+8):before,.grid-cols-8.xl\:grid-line-x>:nth-child(8n+1):nth-last-child(-n+8)~:before{--gridline-x-width:0}.grid-cols-9.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-9.xl\:grid-line-x>:nth-child(9n+1):before{--gridline-x-start:0}.grid-cols-9.xl\:grid-line-x>:nth-child(9n+9):before{--gridline-x-end:0}.grid-cols-9.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-9.xl\:grid-line-x>:nth-child(9n+1):nth-last-child(-n+9):before,.grid-cols-9.xl\:grid-line-x>:nth-child(9n+1):nth-last-child(-n+9)~:before{--gridline-x-width:0}.grid-cols-10.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-10.xl\:grid-line-x>:nth-child(10n+1):before{--gridline-x-start:0}.grid-cols-10.xl\:grid-line-x>:nth-child(10n+10):before{--gridline-x-end:0}.grid-cols-10.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-10.xl\:grid-line-x>:nth-child(10n+1):nth-last-child(-n+10):before,.grid-cols-10.xl\:grid-line-x>:nth-child(10n+1):nth-last-child(-n+10)~:before{--gridline-x-width:0}.grid-cols-11.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-11.xl\:grid-line-x>:nth-child(11n+1):before{--gridline-x-start:0}.grid-cols-11.xl\:grid-line-x>:nth-child(11n+11):before{--gridline-x-end:0}.grid-cols-11.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-11.xl\:grid-line-x>:nth-child(11n+1):nth-last-child(-n+11):before,.grid-cols-11.xl\:grid-line-x>:nth-child(11n+1):nth-last-child(-n+11)~:before{--gridline-x-width:0}.grid-cols-12.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-12.xl\:grid-line-x>:nth-child(12n+1):before{--gridline-x-start:0}.grid-cols-12.xl\:grid-line-x>:nth-child(12n+12):before{--gridline-x-end:0}.grid-cols-12.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-12.xl\:grid-line-x>:nth-child(12n+1):nth-last-child(-n+12):before,.grid-cols-12.xl\:grid-line-x>:nth-child(12n+1):nth-last-child(-n+12)~:before{--gridline-x-width:0}.grid-cols-1.xl\:grid-line-x>:nth-child(n):before{--gridline-x-width:1px;--gridline-x-start:0;--gridline-x-end:0}.grid-cols-1.xl\:grid-line-x>:nth-child(n+1):before{--gridline-x-end:0}.grid-cols-1.xl\:grid-line-x>:nth-child(n):nth-last-child(n):before{--gridline-x-width:1px}.grid-cols-1.xl\:grid-line-x>:nth-child(n+1):nth-last-child(-n+1):before,.grid-cols-1.xl\:grid-line-x>:nth-child(n+1):nth-last-child(-n+1)~:before{--gridline-x-width:0}.xl\:grid-line-x-32>:before,.xl\:grid-line-x-32.grid-line-yfull>:after{--gridline-x-bottom:-32px;--gridline-y-top:-32px;--gridline-y-bottom:-32px}.xl\:w-cols-8>*{--container-grid-columns:8;--cols-container:0}.xl\:grid-line-x-primary>:before{--gridline-x-color:var(--color-grey-90)}}@media (min-width:1520px){.xxl\:w-cols-6{width:calc(((6/var(--container-grid-columns,var(--grid-columns)))*(100% - (var(--inner-gutter)*var(--cols-container,0)))) - (var(--inner-gutter) - (6/var(--container-grid-columns,var(--grid-columns))*var(--inner-gutter))))}.xxl\:w-cols-6>*{--container-grid-columns:6;--cols-container:0}}@media (hover:hover){.hover-hover\:bg-column-alt{background-color:var(--color-blue-04)}}}@property --tw-rotate-x{syntax:"*";inherits:false}@property --tw-rotate-y{syntax:"*";inherits:false}@property --tw-rotate-z{syntax:"*";inherits:false}@property --tw-skew-x{syntax:"*";inherits:false}@property --tw-skew-y{syntax:"*";inherits:false}@property --tw-border-style{syntax:"*";inherits:false;initial-value:solid}@property --tw-font-weight{syntax:"*";inherits:false}@property --tw-blur{syntax:"*";inherits:false}@property --tw-brightness{syntax:"*";inherits:false}@property --tw-contrast{syntax:"*";inherits:false}@property --tw-grayscale{syntax:"*";inherits:false}@property --tw-hue-rotate{syntax:"*";inherits:false}@property --tw-invert{syntax:"*";inherits:false}@property --tw-opacity{syntax:"*";inherits:false}@property --tw-saturate{syntax:"*";inherits:false}@property --tw-sepia{syntax:"*";inherits:false}@property --tw-drop-shadow{syntax:"*";inherits:false}@property --tw-drop-shadow-color{syntax:"*";inherits:false}@property --tw-drop-shadow-alpha{syntax:"<percentage>";inherits:false;initial-value:100%}@property --tw-drop-shadow-size{syntax:"*";inherits:false}@property --tw-ease{syntax:"*";inherits:false}@property --tw-content{syntax:"*";inherits:false;initial-value:""}
+/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
+@layer properties;
+@layer theme, base, components, utilities;
+@layer theme {
+  :root, :host {
+    --spacing: 1px;
+    --font-weight-bold: 700;
+    --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+    --default-transition-duration: 150ms;
+    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities {
+  .dev-tools-grid {
+    position: fixed;
+    z-index: 1;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    top: 0;
+    bottom: 0;
+    width: calc(var(--container-width, 100%) - (2 * var(--outer-gutter, 0)));;
+    height: 100%;
+    margin: 0 auto;
+    background: repeating-linear-gradient(
+        90deg,
+        var(--grid-column-bg),
+        var(--grid-column-bg) calc((100% - (((var(--grid-columns) - 1) * var(--inner-gutter)))) / var(--grid-columns)),
+        rgba(0,0,0,0) calc((100% - (((var(--grid-columns) - 1) * var(--inner-gutter)))) / var(--grid-columns)),
+        rgba(0,0,0,0) calc((100% - (((var(--grid-columns) - 1) * var(--inner-gutter)))) / var(--grid-columns) + var(--inner-gutter))
+      );
+    pointer-events: none;
+  }
+  .grid-line-yfull {
+    & > * {
+      position: relative;
+    }
+    & > *::before {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      content: "";
+      inset-inline-start: 0;
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: var(--gridline-y-top, calc(var(--inner-gutter) / -1));
+      bottom: 0;
+      border-inline-start: 0 solid transparent;
+      border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+    }
+    &.grid-line-x > *::after {
+      inset-inline-start: 0;
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: var(--gridline-y-top, calc(var(--inner-gutter) / -2));
+      bottom: var(--gridline-y-bottom, calc(var(--inner-gutter) / -2));
+      border-inline-start: 0 solid transparent;
+      border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+    }
+    &.grid-line-xfull > *::after {
+      inset-inline-start: 0;
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: var(--gridline-y-top, calc(var(--inner-gutter) / -2));
+      bottom: var(--gridline-y-bottom, calc(var(--inner-gutter) / -2));
+      border-inline-start: 0 solid transparent;
+      border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+    }
+  }
+  .grid-line-x {
+    & > * {
+      position: relative;
+    }
+    & > *::before {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::before {
+      content: "";
+      inset-inline-start: var(--gridline-x-start, 0);
+      inset-inline-end: var(--gridline-x-end, 0);
+      top: 0;
+      bottom: var(--gridline-x-bottom, calc(var(--inner-gutter) / -2));
+      border-top: 0 solid transparent;
+      border-bottom: var(--gridline-x-width, 0) solid var(--gridline-x-color, transparent);
+    }
+  }
+  .grid-line-xfull {
+    & > * {
+      position: relative;
+    }
+    & > *::before {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::before {
+      content: "";
+      inset-inline-start: var(--gridline-x-start, calc(var(--inner-gutter) / -2));
+      inset-inline-end: var(--gridline-x-end, calc(var(--inner-gutter) / -2));
+      top: 0;
+      bottom: var(--gridline-x-bottom, calc(var(--inner-gutter) / -2));
+      border-top: 0 solid transparent;
+      border-bottom: var(--gridline-x-width, 0) solid var(--gridline-x-color, transparent);
+    }
+  }
+  .grid-line-y {
+    & > * {
+      position: relative;
+    }
+    & > *::before {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      content: "";
+      inset-inline-start: 0;
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: 0;
+      bottom: 0;
+      border-inline-start: 0 solid transparent;
+      border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+    }
+  }
+  .keyline-l-primary {
+    position: relative;
+    --keyline-l-color: var(--color-grey-90);
+    --keyline-r-color: transparent;
+    &::before {
+      content: "";
+      position: absolute;
+      z-index: 0;
+      inset-inline-start: calc(var(--inner-gutter) / -2 - 1px);
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: 0;
+      bottom: 0;
+      border-left: 1px solid var(--keyline-l-color, transparent);
+      border-right: 1px solid var(--keyline-r-color, transparent);
+      pointer-events: none;
+    }
+  }
+  .keyline-r-primary {
+    position: relative;
+    --keyline-l-color: transparent;
+    --keyline-r-color: var(--color-grey-90);
+    &::before {
+      content: "";
+      position: absolute;
+      z-index: 0;
+      inset-inline-start: calc(var(--inner-gutter) / -2 - 1px);
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: 0;
+      bottom: 0;
+      border-left: 1px solid var(--keyline-l-color, transparent);
+      border-right: 1px solid var(--keyline-r-color, transparent);
+      pointer-events: none;
+    }
+  }
+  .background-fill {
+    --background-fill-bg: inherit;
+    position: relative;
+    &::before {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      inset-inline-start: 50%;
+      top: 0;
+      bottom: 0;
+      width: 100vw;
+      margin-inline-start: -50vw;
+      background-color: var(--background-fill-bg, inherit);
+      pointer-events: none;
+    }
+  }
+  .background-fill-accent {
+    --background-fill-bg: var(--color-blue-03);
+    position: relative;
+    &::before {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      inset-inline-start: 50%;
+      top: 0;
+      bottom: 0;
+      width: 100vw;
+      margin-inline-start: -50vw;
+      background-color: var(--background-fill-bg, inherit);
+      pointer-events: none;
+    }
+  }
+  .background-fill-header {
+    --background-fill-bg: var(--color-grey-10);
+    position: relative;
+    &::before {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      inset-inline-start: 50%;
+      top: 0;
+      bottom: 0;
+      width: 100vw;
+      margin-inline-start: -50vw;
+      background-color: var(--background-fill-bg, inherit);
+      pointer-events: none;
+    }
+  }
+  .stroke-full-top {
+    --stroke-full-thickness: 0.0625em;
+    --stroke-full-style: solid;
+    --stroke-full-color: inherit;
+    position: relative;
+    &::after {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      inset-inline-start: 50%;
+      top: 0;
+      bottom: 100%;
+      width: 100vw;
+      margin-inline-start: -50vw;
+      pointer-events: none;
+      border-bottom: var(--stroke-full-thickness, 0.0625em) var(--stroke-full-style, solid) var(--stroke-full-color, inherit);
+    }
+  }
+  .stroke-full-bottom {
+    --stroke-full-thickness: 0.0625em;
+    --stroke-full-style: solid;
+    --stroke-full-color: inherit;
+    position: relative;
+    &::after {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      inset-inline-start: 50%;
+      top: 100%;
+      width: 100vw;
+      margin-inline-start: -50vw;
+      pointer-events: none;
+      border-top: var(--stroke-full-thickness, 0.0625em) var(--stroke-full-style, solid) var(--stroke-full-color, inherit);
+    }
+  }
+  .dev-tools {
+    position: fixed;
+    z-index: 9999999999;
+    inset-inline-start: 0;
+    bottom: 0;
+    font-size: 0;
+    &::before {
+      content: var(--breakpoint) " • " var(--env);
+      position: absolute;
+      z-index: 2;
+      inset-inline-start: 0;
+      bottom: 100%;
+      padding: 4px 5px;
+      background: green;
+      color: white;
+      font: 12px/1 sans-serif;
+      white-space: nowrap;
+      pointer-events: none;
+    }
+  }
+  .grid-line-x-0 {
+    & > * {
+      position: relative;
+    }
+    & > *::before {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::before {
+      content: none;
+    }
+  }
+  .grid-line-y-0 {
+    & > * {
+      position: relative;
+    }
+    & > *::before {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      position: absolute;
+      z-index: 0;
+      pointer-events: none;
+    }
+    & > *::after {
+      content: none;
+    }
+  }
+  .pointer-events-none {
+    pointer-events: none;
+  }
+  .collapse {
+    visibility: collapse;
+  }
+  .invisible {
+    visibility: hidden;
+  }
+  .visible {
+    visibility: visible;
+  }
+  .dev-tools-toggle {
+    position: relative;
+    z-index: 2;
+    width: 30px;
+    height: 30px;
+    border: 0;
+    background: black;
+    color: transparent;
+    font: 0/0 a;
+    appearance: none;
+    cursor: pointer;
+    &::before {
+      content: '';
+      position: absolute;
+      inset-inline-start: 8px;
+      top: 10px;
+      width: 5px;
+      height: 10px;
+      border-inline-start: 1px solid white;
+      border-inline-end: 1px solid white;
+    }
+    &::after {
+      content: '';
+      position: absolute;
+      inset-inline-start: 8px;
+      top: 10px;
+      width: 5px;
+      height: 10px;
+      border-inline-start: 1px solid white;
+      border-inline-end: 1px solid white;
+    }
+    &::after {
+      inset-inline-start: 16px;
+    }
+  }
+  .container {
+    &[class] {
+      width: calc(var(--container-width, 100%) - (2 * var(--breakout-container-outer-gutter, var(--container-outer-gutter, var(--outer-gutter, 0)))));
+      margin-right: auto;
+      margin-left: auto;
+    }
+    &[class] > * {
+      --container-outer-gutter: 0;
+      --breakout-container-outer-gutter: 0;
+    }
+    &[class] > .breakout[class] {
+      --breakout-outer-gutter: max(var(--outer-gutter), calc((100% - var(--container-width, 100%)) / 2));
+      --breakout-container-outer-gutter: var(--outer-gutter);
+      position: relative;
+      inset-inline-start: 50%;
+      width: calc(100vw - var(--scrollbar-visible-width, 0px));
+      margin-inline-start: calc((100vw - var(--scrollbar-visible-width, 0px)) / -2);
+    }
+  }
+  .breakout {
+    &[class] {
+      --breakout-outer-gutter: max(var(--outer-gutter), calc((100% - var(--container-width, 100%)) / 2));
+      --breakout-container-outer-gutter: var(--outer-gutter);
+      position: relative;
+      inset-inline-start: 50%;
+      width: calc(100vw - var(--scrollbar-visible-width, 0px));
+      margin-inline-start: calc((100vw - var(--scrollbar-visible-width, 0px)) / -2);
+    }
+    .container[class] > &[class] {
+      --breakout-outer-gutter: max(var(--outer-gutter), calc((100% - var(--container-width, 100%)) / 2));
+      --breakout-container-outer-gutter: var(--outer-gutter);
+      position: relative;
+      inset-inline-start: 50%;
+      width: calc(100vw - var(--scrollbar-visible-width, 0px));
+      margin-inline-start: calc((100vw - var(--scrollbar-visible-width, 0px)) / -2);
+    }
+    &[class].px-outer-gutter {
+      padding-inline-start: var(--breakout-outer-gutter);
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+    &[class] > .px-outer-gutter {
+      padding-inline-start: var(--breakout-outer-gutter);
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+    &[class].pr-outer-gutter {
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+    &[class] > .pr-outer-gutter {
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+    &[class].pl-outer-gutter {
+      padding-inline-start: var(--breakout-outer-gutter);
+    }
+    &[class] > .pl-outer-gutter {
+      padding-inline-start: var(--breakout-outer-gutter);
+    }
+    &[class] > .w-outer-gutter {
+      width: var(--breakout-outer-gutter);
+    }
+  }
+  .breakout-reset {
+    &[class] {
+      --breakout-outer-gutter: var(--outer-gutter);
+      --breakout-container-outer-gutter: 0;
+      position: unset;
+      inset-inline-start: unset;
+      width: unset;
+      margin-inline-start: unset;
+    }
+  }
+  .ratio {
+    --ratio: 100%;
+    display: block;
+    position: relative;
+    overflow: hidden;
+    &::before {
+      content: "";
+      display: block;
+      width: 100%;
+      height: 0;
+      padding-bottom: var(--ratio);
+    }
+    & > [class*="ratio-content"] {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+  .ratio-free {
+    &::before {
+      content: unset;
+    }
+    &::after {
+      content: unset;
+    }
+    & > [class*="ratio-content"] {
+      position: static;
+      left: auto;
+      right: auto;
+      top: auto;
+      bottom: auto;
+      width: auto;
+      height: auto;
+    }
+    & > [class*="ratio-content"][class*="w-full"] {
+      width: 100%;
+    }
+    & > [class*="ratio-content"][class*="h-auto"] {
+      height: auto;
+    }
+  }
+  .absolute {
+    position: absolute;
+  }
+  .fixed {
+    position: fixed;
+  }
+  .relative {
+    position: relative;
+  }
+  .static {
+    position: static;
+  }
+  .grid-line-x {
+    .grid-line-yfull& > *::after {
+      inset-inline-start: 0;
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: var(--gridline-y-top, calc(var(--inner-gutter) / -2));
+      bottom: var(--gridline-y-bottom, calc(var(--inner-gutter) / -2));
+      border-inline-start: 0 solid transparent;
+      border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+    }
+  }
+  .grid-line-xfull {
+    .grid-line-yfull& > *::after {
+      inset-inline-start: 0;
+      inset-inline-end: calc(var(--inner-gutter) / -2);
+      top: var(--gridline-y-top, calc(var(--inner-gutter) / -2));
+      bottom: var(--gridline-y-bottom, calc(var(--inner-gutter) / -2));
+      border-inline-start: 0 solid transparent;
+      border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+    }
+  }
+  .start {
+    inset-inline-start: var(--spacing);
+  }
+  .start-cols-2 {
+    inset-inline-start: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .end {
+    inset-inline-end: var(--spacing);
+  }
+  .end-cols-4 {
+    inset-inline-end: calc(((((4 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (4 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .top-0 {
+    top: calc(var(--spacing) * 0);
+  }
+  .top-40 {
+    top: calc(var(--spacing) * 40);
+  }
+  .top-56 {
+    top: calc(var(--spacing) * 56);
+  }
+  .top-60 {
+    top: calc(var(--spacing) * 60);
+  }
+  .top-\[var\(--offset\)\] {
+    top: var(--offset);
+  }
+  .right-0 {
+    right: calc(var(--spacing) * 0);
+  }
+  .right-full {
+    right: 100%;
+  }
+  .-left-8 {
+    left: calc(var(--spacing) * -8);
+  }
+  .-left-99999 {
+    left: calc(var(--spacing) * -99999);
+  }
+  .left-0 {
+    left: calc(var(--spacing) * 0);
+  }
+  .left-\[-99999px\] {
+    left: -99999px;
+  }
+  .left-cols-1 {
+    left: calc(((((1 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (1 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .left-cols-1\/3 {
+    left: calc(((33.333% - (var(--inner-gutter) * max(0.666, var(--cols-container, 0)))) + var(--inner-gutter)));
+  }
+  .grid-col-span-1 {
+    --container-grid-columns: 1;
+    grid-column: span 1 / span 1;
+  }
+  .grid-col-span-2 {
+    --container-grid-columns: 2;
+    grid-column: span 2 / span 2;
+  }
+  .grid-col-span-3 {
+    --container-grid-columns: 3;
+    grid-column: span 3 / span 3;
+  }
+  .grid-col-span-6 {
+    --container-grid-columns: 6;
+    grid-column: span 6 / span 6;
+  }
+  .grid-col-span-8 {
+    --container-grid-columns: 8;
+    grid-column: span 8 / span 8;
+  }
+  .grid-col-span-9 {
+    --container-grid-columns: 9;
+    grid-column: span 9 / span 9;
+  }
+  .grid-col-start-1 {
+    grid-column-start: 1;
+  }
+  .grid-col-start-4 {
+    grid-column-start: 4;
+  }
+  .grid-col-end-1 {
+    grid-column-end: 1;
+  }
+  .grid-col-end-13 {
+    grid-column-end: 13;
+  }
+  .row-span-3 {
+    grid-row: span 3 / span 3;
+  }
+  .row-span-full {
+    grid-row: 1 / -1;
+  }
+  .row-end-3 {
+    grid-row-end: 3;
+  }
+  .ratio-expandable {
+    &::before {
+      float: left;
+      width: 1px;
+      margin-inline-start: -1px;
+    }
+    &::after {
+      content: "";
+      display: table;
+      clear: both;
+    }
+  }
+  .container {
+    width: 100%;
+    @media (width >= 0) {
+      max-width: 0;
+    }
+    @media (width >= 544px) {
+      max-width: 544px;
+    }
+    @media (width >= 650px) {
+      max-width: 650px;
+    }
+    @media (width >= 990px) {
+      max-width: 990px;
+    }
+    @media (width >= 1300px) {
+      max-width: 1300px;
+    }
+    @media (width >= 1520px) {
+      max-width: 1520px;
+    }
+  }
+  .m-0 {
+    margin: calc(var(--spacing) * 0);
+  }
+  .-mx-outer-1 {
+    margin-inline: calc(var(--spacing-outer-1) * -1);
+  }
+  .mx-40 {
+    margin-inline: calc(var(--spacing) * 40);
+  }
+  .mx-auto {
+    margin-inline: auto;
+  }
+  .mx-cols-1 {
+    margin-inline: calc(((((1 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (1 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .mx-cols-3 {
+    margin-inline: calc(((((3 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (3 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .mx-outer-1 {
+    margin-inline: var(--spacing-outer-1);
+  }
+  .my-40 {
+    margin-block: calc(var(--spacing) * 40);
+  }
+  .ms-0 {
+    margin-inline-start: calc(var(--spacing) * 0);
+  }
+  .ms-cols-2 {
+    margin-inline-start: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .me-cols-2 {
+    margin-inline-end: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .-mt-\(--spacing-outer-1\) {
+    margin-top: calc(var(--spacing-outer-1) * -1);
+  }
+  .mt-\(--spacing-outer-1\) {
+    margin-top: var(--spacing-outer-1);
+  }
+  .mt-0 {
+    margin-top: calc(var(--spacing) * 0);
+  }
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
+  }
+  .mt-4 {
+    margin-top: calc(var(--spacing) * 4);
+  }
+  .mt-8 {
+    margin-top: calc(var(--spacing) * 8);
+  }
+  .mt-12 {
+    margin-top: calc(var(--spacing) * 12);
+  }
+  .mt-16 {
+    margin-top: calc(var(--spacing) * 16);
+  }
+  .mt-20 {
+    margin-top: calc(var(--spacing) * 20);
+  }
+  .mt-40 {
+    margin-top: calc(var(--spacing) * 40);
+  }
+  .mt-56 {
+    margin-top: calc(var(--spacing) * 56);
+  }
+  .mt-60 {
+    margin-top: calc(var(--spacing) * 60);
+  }
+  .mt-inner-2 {
+    margin-top: var(--spacing-inner-2);
+  }
+  .mt-outer-1 {
+    margin-top: var(--spacing-outer-1);
+  }
+  .container-reset {
+    &[class] {
+      width: unset;
+      margin-right: unset;
+      margin-left: unset;
+    }
+    &[class] > * {
+      --container-outer-gutter: var(--outer-gutter, 0);
+      --breakout-container-outer-gutter: inherit;
+    }
+  }
+  .mr-8 {
+    margin-right: calc(var(--spacing) * 8);
+  }
+  .mr-cols-1 {
+    margin-right: calc(((((1 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (1 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .mr-cols-2 {
+    margin-right: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .mr-cols-vw-2 {
+    margin-right: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 2) + (1 * var(--inner-gutter)));
+  }
+  .mb-16 {
+    margin-bottom: calc(var(--spacing) * 16);
+  }
+  .mb-60 {
+    margin-bottom: calc(var(--spacing) * 60);
+  }
+  .cols-container {
+    display: flex;
+    flex-flow: row wrap;
+    margin-left: calc(var(--inner-gutter) * -1);
+    & > [class*="-cols"] {
+      --cols-container: 1;
+      margin-left: var(--inner-gutter);
+    }
+    & > .ml-0 {
+      margin-left: 0;
+    }
+    & > .ms-0 {
+      margin-left: 0;
+    }
+  }
+  .ml-0 {
+    margin-left: calc(var(--spacing) * 0);
+  }
+  .ml-16 {
+    margin-left: calc(var(--spacing) * 16);
+  }
+  .ml-auto {
+    margin-left: auto;
+  }
+  .ml-cols-2 {
+    margin-left: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .ml-cols-2\/3 {
+    margin-left: calc(((66.666% - (var(--inner-gutter) * max(0.333, var(--cols-container, 0)))) + var(--inner-gutter)));
+  }
+  .ml-cols-no-gutter-2 {
+    margin-left: calc(((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .ml-cols-vw-2 {
+    margin-left: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 2) + (1 * var(--inner-gutter)));
+  }
+  .full-bleed-scroller-reset {
+    display: unset;
+    flex-flow: unset;
+    flex-wrap: unset;
+    overflow-x: unset;
+    &::before {
+      content: none;
+      flex: unset;
+      width: unset;
+    }
+    &::after {
+      content: none;
+      flex: unset;
+      width: unset;
+    }
+  }
+  .full-bleed-scroller {
+    display: flex;
+    flex-flow: row nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: var(--inner-gutter);
+    &::before {
+      content: '';
+      flex: 0 0 auto;
+      width: calc(var(--breakout-outer-gutter, var(--outer-gutter, 0px)) - var(--inner-gutter, 0px));
+    }
+    &::after {
+      content: '';
+      flex: 0 0 auto;
+      width: calc(var(--breakout-outer-gutter, var(--outer-gutter, 0px)) - var(--inner-gutter, 0px));
+    }
+  }
+  .grid-layout {
+    display: grid;
+    grid-template-columns: repeat(var(--container-grid-columns, var(--grid-columns)), 1fr);
+    grid-gap: var(--inner-gutter);
+  }
+  .scrollbar-none {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+  .block {
+    display: block;
+  }
+  .flex {
+    display: flex;
+  }
+  .grid {
+    display: grid;
+  }
+  .hidden {
+    display: none;
+  }
+  .inline {
+    display: inline;
+  }
+  .inline-block {
+    display: inline-block;
+  }
+  .table {
+    display: table;
+  }
+  .scrollbar-thin {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-thin-collapse {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-thumb-bg-column-alt {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-thumb-primary {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-thumb-red-01 {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-track-bg-column {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-track-grey-15 {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .scrollbar-track-primary {
+    --scrollbar-bg: #fafafa;
+    --scrollbar-fg: #c1c1c1;
+    --scrollbar-border: #e8e8e8;
+    scrollbar-color: var(--scrollbar-fg) var(--scrollbar-bg);
+    &::-webkit-scrollbar {
+      width: var(--scrollbar-width, unset);
+      height: var(--scrollbar-width, unset);
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--scrollbar-bg);
+    }
+    &::-webkit-scrollbar-track:horizontal {
+      border-block-start: 1px solid var(--scrollbar-border);
+      border-block-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-track:vertical {
+      border-inline-start: 1px solid var(--scrollbar-border);
+      border-inline-end: 1px solid var(--scrollbar-border);
+    }
+    &::-webkit-scrollbar-thumb {
+      background: var(--scrollbar-fg);
+      border-radius: 20px;
+      border: var(--scrollbar-padding, 4px) solid transparent;
+      background-clip: content-box;
+    }
+  }
+  .h-0 {
+    height: calc(var(--spacing) * 0);
+  }
+  .h-1 {
+    height: calc(var(--spacing) * 1);
+  }
+  .h-2 {
+    height: calc(var(--spacing) * 2);
+  }
+  .h-3 {
+    height: calc(var(--spacing) * 3);
+  }
+  .h-4 {
+    height: calc(var(--spacing) * 4);
+  }
+  .h-5 {
+    height: calc(var(--spacing) * 5);
+  }
+  .h-6 {
+    height: calc(var(--spacing) * 6);
+  }
+  .h-7 {
+    height: calc(var(--spacing) * 7);
+  }
+  .h-8 {
+    height: calc(var(--spacing) * 8);
+  }
+  .h-9 {
+    height: calc(var(--spacing) * 9);
+  }
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
+  .h-16 {
+    height: calc(var(--spacing) * 16);
+  }
+  .h-20 {
+    height: calc(var(--spacing) * 20);
+  }
+  .h-24 {
+    height: calc(var(--spacing) * 24);
+  }
+  .h-28 {
+    height: calc(var(--spacing) * 28);
+  }
+  .h-32 {
+    height: calc(var(--spacing) * 32);
+  }
+  .h-36 {
+    height: calc(var(--spacing) * 36);
+  }
+  .h-40 {
+    height: calc(var(--spacing) * 40);
+  }
+  .h-44 {
+    height: calc(var(--spacing) * 44);
+  }
+  .h-48 {
+    height: calc(var(--spacing) * 48);
+  }
+  .h-52 {
+    height: calc(var(--spacing) * 52);
+  }
+  .h-56 {
+    height: calc(var(--spacing) * 56);
+  }
+  .h-60 {
+    height: calc(var(--spacing) * 60);
+  }
+  .h-64 {
+    height: calc(var(--spacing) * 64);
+  }
+  .h-68 {
+    height: calc(var(--spacing) * 68);
+  }
+  .h-72 {
+    height: calc(var(--spacing) * 72);
+  }
+  .h-76 {
+    height: calc(var(--spacing) * 76);
+  }
+  .h-80 {
+    height: calc(var(--spacing) * 80);
+  }
+  .h-84 {
+    height: calc(var(--spacing) * 84);
+  }
+  .h-88 {
+    height: calc(var(--spacing) * 88);
+  }
+  .h-92 {
+    height: calc(var(--spacing) * 92);
+  }
+  .h-96 {
+    height: calc(var(--spacing) * 96);
+  }
+  .h-100 {
+    height: calc(var(--spacing) * 100);
+  }
+  .h-120 {
+    height: calc(var(--spacing) * 120);
+  }
+  .h-400 {
+    height: calc(var(--spacing) * 400);
+  }
+  .h-600 {
+    height: calc(var(--spacing) * 600);
+  }
+  .h-auto {
+    height: auto;
+  }
+  .max-h-400 {
+    max-height: calc(var(--spacing) * 400);
+  }
+  .max-h-600 {
+    max-height: calc(var(--spacing) * 600);
+  }
+  .min-h-0 {
+    min-height: calc(var(--spacing) * 0);
+  }
+  .min-h-40 {
+    min-height: calc(var(--spacing) * 40);
+  }
+  .min-h-screen {
+    min-height: 100vh;
+  }
+  .w-0 {
+    width: calc(var(--spacing) * 0);
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
+  }
+  .w-2 {
+    width: calc(var(--spacing) * 2);
+  }
+  .w-3 {
+    width: calc(var(--spacing) * 3);
+  }
+  .w-4 {
+    width: calc(var(--spacing) * 4);
+  }
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+  .w-6 {
+    width: calc(var(--spacing) * 6);
+  }
+  .w-7 {
+    width: calc(var(--spacing) * 7);
+  }
+  .w-8 {
+    width: calc(var(--spacing) * 8);
+  }
+  .w-9 {
+    width: calc(var(--spacing) * 9);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+  .w-12 {
+    width: calc(var(--spacing) * 12);
+  }
+  .w-16 {
+    width: calc(var(--spacing) * 16);
+  }
+  .w-20 {
+    width: calc(var(--spacing) * 20);
+  }
+  .w-24 {
+    width: calc(var(--spacing) * 24);
+  }
+  .w-28 {
+    width: calc(var(--spacing) * 28);
+  }
+  .w-32 {
+    width: calc(var(--spacing) * 32);
+  }
+  .w-36 {
+    width: calc(var(--spacing) * 36);
+  }
+  .w-40 {
+    width: calc(var(--spacing) * 40);
+  }
+  .w-44 {
+    width: calc(var(--spacing) * 44);
+  }
+  .w-48 {
+    width: calc(var(--spacing) * 48);
+  }
+  .w-52 {
+    width: calc(var(--spacing) * 52);
+  }
+  .w-56 {
+    width: calc(var(--spacing) * 56);
+  }
+  .w-60 {
+    width: calc(var(--spacing) * 60);
+  }
+  .w-64 {
+    width: calc(var(--spacing) * 64);
+  }
+  .w-68 {
+    width: calc(var(--spacing) * 68);
+  }
+  .w-72 {
+    width: calc(var(--spacing) * 72);
+  }
+  .w-76 {
+    width: calc(var(--spacing) * 76);
+  }
+  .w-80 {
+    width: calc(var(--spacing) * 80);
+  }
+  .w-84 {
+    width: calc(var(--spacing) * 84);
+  }
+  .w-88 {
+    width: calc(var(--spacing) * 88);
+  }
+  .w-92 {
+    width: calc(var(--spacing) * 92);
+  }
+  .w-96 {
+    width: calc(var(--spacing) * 96);
+  }
+  .w-100 {
+    width: calc(var(--spacing) * 100);
+  }
+  .w-400 {
+    width: calc(var(--spacing) * 400);
+  }
+  .w-600 {
+    width: calc(var(--spacing) * 600);
+  }
+  .w-cols-1 {
+    width: calc(((1 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (1 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-1\/2 {
+    width: calc(50% - (var(--inner-gutter) * max(0.5, var(--cols-container, 0))));
+  }
+  .w-cols-1\/3 {
+    width: calc(33.333% - (var(--inner-gutter) * max(0.666, var(--cols-container, 0))));
+  }
+  .w-cols-1\/4 {
+    width: calc(25% - (var(--inner-gutter) * max(0.75, var(--cols-container, 0))));
+  }
+  .w-cols-2 {
+    width: calc(((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-2\/3 {
+    width: calc(66.666% - (var(--inner-gutter) * max(0.333, var(--cols-container, 0))));
+  }
+  .w-cols-3 {
+    width: calc(((3 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (3 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-3\/4 {
+    width: calc(75% - (var(--inner-gutter) * max(0.25, var(--cols-container, 0))));
+  }
+  .w-cols-4 {
+    width: calc(((4 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (4 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-5 {
+    width: calc(((5 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (5 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-6 {
+    width: calc(((6 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (6 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-7 {
+    width: calc(((7 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (7 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-8 {
+    width: calc(((8 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (8 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-9 {
+    width: calc(((9 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (9 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-10 {
+    width: calc(((10 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (10 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-11 {
+    width: calc(((11 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (11 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-12 {
+    width: calc(((12 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (12 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+  }
+  .w-cols-vw-1 {
+    width: calc(((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))));
+  }
+  .w-cols-vw-2 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 2) + (1 * var(--inner-gutter)));
+  }
+  .w-cols-vw-3 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 3) + (2 * var(--inner-gutter)));
+  }
+  .w-cols-vw-4 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 4) + (3 * var(--inner-gutter)));
+  }
+  .w-cols-vw-5 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 5) + (4 * var(--inner-gutter)));
+  }
+  .w-cols-vw-6 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 6) + (5 * var(--inner-gutter)));
+  }
+  .w-cols-vw-7 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 7) + (6 * var(--inner-gutter)));
+  }
+  .w-cols-vw-8 {
+    width: calc((((var(--container-width, 100vw - var(--scrollbar-visible-width, 0px)) - (((var(--grid-columns) - 1) * var(--inner-gutter)) + (2 * var(--outer-gutter)))) / (var(--grid-columns))) * 8) + (7 * var(--inner-gutter)));
+  }
+  .w-full {
+    width: 100%;
+  }
+  .w-outer-gutter {
+    .breakout[class] > & {
+      width: var(--breakout-outer-gutter);
+    }
+  }
+  .\!max-w-full {
+    max-width: 100% !important;
+  }
+  .container {
+    max-width: 100%;
+  }
+  .max-w-400 {
+    max-width: calc(var(--spacing) * 400);
+  }
+  .max-w-full {
+    max-width: 100%;
+  }
+  .flex-none {
+    flex: none;
+  }
+  .flex-shrink-0 {
+    flex-shrink: 0;
+  }
+  .shrink-0 {
+    flex-shrink: 0;
+  }
+  .flex-grow {
+    flex-grow: 1;
+  }
+  .grow {
+    flex-grow: 1;
+  }
+  .transform {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
+  .cursor-pointer {
+    cursor: pointer;
+  }
+  .resize {
+    resize: both;
+  }
+  .list-decimal {
+    list-style-type: decimal;
+  }
+  .list-disc {
+    list-style-type: disc;
+  }
+  .appearance-none {
+    appearance: none;
+  }
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .flex-col {
+    flex-direction: column;
+  }
+  .flex-row {
+    flex-direction: row;
+  }
+  .flex-nowrap {
+    flex-wrap: nowrap;
+  }
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .justify-center {
+    justify-content: center;
+  }
+  .justify-end {
+    justify-content: flex-end;
+  }
+  .gap-gutter {
+    grid-gap: var(--inner-gutter);
+    gap: var(--inner-gutter);
+  }
+  .gap-x-gutter {
+    grid-column-gap: var(--inner-gutter);
+    column-gap: var(--inner-gutter);
+  }
+  .gap-x-0 {
+    column-gap: calc(var(--spacing) * 0);
+  }
+  .gap-y-gutter {
+    grid-row-gap: var(--inner-gutter);
+    row-gap: var(--inner-gutter);
+  }
+  .gap-y-20 {
+    row-gap: calc(var(--spacing) * 20);
+  }
+  .gap-y-48 {
+    row-gap: calc(var(--spacing) * 48);
+  }
+  .gap-y-80 {
+    row-gap: calc(var(--spacing) * 80);
+  }
+  .overflow-auto {
+    overflow: auto;
+  }
+  .overflow-x-auto {
+    overflow-x: auto;
+  }
+  .overflow-x-hidden {
+    overflow-x: hidden;
+  }
+  .overflow-y-scroll {
+    overflow-y: scroll;
+  }
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+  .border-l-0 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 0px;
+  }
+  .border-l-1 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 1px;
+  }
+  .border-code-example-filename {
+    [class*="theme-"] & {
+      border-color: var(--border-code-example-filename, var(--color-blue-05));
+    }
+  }
+  .border-code-example-filename {
+    border-color: var(--color-blue-05);
+  }
+  .border-primary {
+    [class*="theme-"] & {
+      border-color: var(--border-primary, var(--color-grey-90));
+    }
+  }
+  .border-primary {
+    border-color: var(--color-grey-90);
+  }
+  .border-secondary {
+    [class*="theme-"] & {
+      border-color: var(--border-secondary, var(--color-grey-30));
+    }
+  }
+  .border-secondary {
+    border-color: var(--color-grey-30);
+  }
+  .border-tertiary {
+    [class*="theme-"] & {
+      border-color: var(--border-tertiary, var(--color-grey-54));
+    }
+  }
+  .border-tertiary {
+    border-color: var(--color-grey-54);
+  }
+  .border-t-secondary {
+    border-top-color: var(--color-grey-30);
+  }
+  .bg-accent {
+    [class*="theme-"] & {
+      background-color: var(--background-accent, var(--color-blue-03));
+    }
+  }
+  .bg-accent {
+    background-color: var(--color-blue-03);
+  }
+  .bg-banner {
+    [class*="theme-"] & {
+      background-color: var(--background-banner, var(--color-grey-90));
+    }
+  }
+  .bg-banner {
+    background-color: var(--color-grey-90);
+  }
+  .bg-code {
+    [class*="theme-"] & {
+      background-color: var(--background-code, var(--color-white));
+    }
+  }
+  .bg-code {
+    background-color: var(--color-white);
+  }
+  .bg-code-example {
+    [class*="theme-"] & {
+      background-color: var(--background-code-example, var(--color-grey-90));
+    }
+  }
+  .bg-code-example {
+    background-color: var(--color-grey-90);
+  }
+  .bg-column {
+    [class*="theme-"] & {
+      background-color: var(--background-column, var(--color-blue-05));
+    }
+  }
+  .bg-column {
+    background-color: var(--color-blue-05);
+  }
+  .bg-column-alt {
+    [class*="theme-"] & {
+      background-color: var(--background-column-alt, var(--color-blue-04));
+    }
+  }
+  .bg-column-alt {
+    background-color: var(--color-blue-04);
+  }
+  .bg-container-demo {
+    [class*="theme-"] & {
+      background-color: var(--background-container-demo, var(--color-white));
+    }
+  }
+  .bg-container-demo {
+    background-color: var(--color-white);
+  }
+  .bg-header {
+    [class*="theme-"] & {
+      background-color: var(--background-header, var(--color-grey-10));
+    }
+  }
+  .bg-header {
+    background-color: var(--color-grey-10);
+  }
+  .bg-inverse {
+    [class*="theme-"] & {
+      background-color: var(--background-inverse, var(--color-black));
+    }
+  }
+  .bg-inverse {
+    background-color: var(--color-black);
+  }
+  .bg-primary {
+    [class*="theme-"] & {
+      background-color: var(--background-primary, var(--color-grey-10));
+    }
+  }
+  .bg-primary {
+    background-color: var(--color-grey-10);
+  }
+  .bg-quote {
+    [class*="theme-"] & {
+      background-color: var(--background-quote, var(--color-grey-5));
+    }
+  }
+  .bg-quote {
+    background-color: var(--color-grey-5);
+  }
+  .p-\(--spacing-inner-1\) {
+    padding: var(--spacing-inner-1);
+  }
+  .p-8 {
+    padding: calc(var(--spacing) * 8);
+  }
+  .p-20 {
+    padding: calc(var(--spacing) * 20);
+  }
+  .p-24 {
+    padding: calc(var(--spacing) * 24);
+  }
+  .p-inner-1 {
+    padding: var(--spacing-inner-1);
+  }
+  .p-inner-2 {
+    padding: var(--spacing-inner-2);
+  }
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+  .px-8 {
+    padding-inline: calc(var(--spacing) * 8);
+  }
+  .px-10 {
+    padding-inline: calc(var(--spacing) * 10);
+  }
+  .px-20 {
+    padding-inline: calc(var(--spacing) * 20);
+  }
+  .px-24 {
+    padding-inline: calc(var(--spacing) * 24);
+  }
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
+  }
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
+  .py-20 {
+    padding-block: calc(var(--spacing) * 20);
+  }
+  .py-24 {
+    padding-block: calc(var(--spacing) * 24);
+  }
+  .py-40 {
+    padding-block: calc(var(--spacing) * 40);
+  }
+  .px-outer-gutter {
+    .breakout[class]& {
+      padding-inline-start: var(--breakout-outer-gutter);
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+    .breakout[class] > & {
+      padding-inline-start: var(--breakout-outer-gutter);
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+  }
+  .pl-outer-gutter {
+    .breakout[class]& {
+      padding-inline-start: var(--breakout-outer-gutter);
+    }
+    .breakout[class] > & {
+      padding-inline-start: var(--breakout-outer-gutter);
+    }
+  }
+  .ps-0 {
+    padding-inline-start: calc(var(--spacing) * 0);
+  }
+  .ps-cols-2 {
+    padding-inline-start: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .ps-inner-1 {
+    padding-inline-start: var(--spacing-inner-1);
+  }
+  .pr-outer-gutter {
+    .breakout[class]& {
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+    .breakout[class] > & {
+      padding-inline-end: var(--breakout-outer-gutter);
+    }
+  }
+  .pe-0 {
+    padding-inline-end: calc(var(--spacing) * 0);
+  }
+  .pe-cols-4 {
+    padding-inline-end: calc(((((4 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (4 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .pt-4 {
+    padding-top: calc(var(--spacing) * 4);
+  }
+  .pt-20 {
+    padding-top: calc(var(--spacing) * 20);
+  }
+  .pt-40 {
+    padding-top: calc(var(--spacing) * 40);
+  }
+  .pt-48 {
+    padding-top: calc(var(--spacing) * 48);
+  }
+  .pt-60 {
+    padding-top: calc(var(--spacing) * 60);
+  }
+  .pt-inner-1 {
+    padding-top: var(--spacing-inner-1);
+  }
+  .pt-outer-1 {
+    padding-top: var(--spacing-outer-1);
+  }
+  .pr-cols-4 {
+    padding-right: calc(((((4 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (4 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .pb-2 {
+    padding-bottom: calc(var(--spacing) * 2);
+  }
+  .pb-4 {
+    padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pb-20 {
+    padding-bottom: calc(var(--spacing) * 20);
+  }
+  .pb-40 {
+    padding-bottom: calc(var(--spacing) * 40);
+  }
+  .pl-3 {
+    padding-left: calc(var(--spacing) * 3);
+  }
+  .pl-16 {
+    padding-left: calc(var(--spacing) * 16);
+  }
+  .pl-cols-2 {
+    padding-left: calc(((((2 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (2 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+  }
+  .text-center {
+    text-align: center;
+  }
+  .align-text-bottom {
+    vertical-align: text-bottom;
+  }
+  .f-body {
+    font-family: var(--f-body-font-family);
+    font-weight: var(--f-body-font-weight);
+    font-size: var(--f-body-font-size);
+    line-height: var(--f-body-line-height);
+    letter-spacing: var(--f-body-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-body--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-body--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+  }
+  .f-code {
+    font-family: var(--f-code-font-family);
+    font-weight: var(--f-code-font-weight);
+    font-size: var(--f-code-font-size);
+    line-height: var(--f-code-line-height);
+    letter-spacing: var(--f-code-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-code--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-code--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+  }
+  .f-h1 {
+    font-family: var(--f-h1-font-family);
+    font-weight: var(--f-h1-font-weight);
+    font-size: var(--f-h1-font-size);
+    line-height: var(--f-h1-line-height);
+    letter-spacing: var(--f-h1-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h1--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h1--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h1---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h1---bold-weight, bold);
+    }
+  }
+  .f-h2 {
+    font-family: var(--f-h2-font-family);
+    font-weight: var(--f-h2-font-weight);
+    font-size: var(--f-h2-font-size);
+    line-height: var(--f-h2-line-height);
+    letter-spacing: var(--f-h2-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h2--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h2--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h2---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h2---bold-weight, bold);
+    }
+  }
+  .f-h3 {
+    font-family: var(--f-h3-font-family);
+    font-weight: var(--f-h3-font-weight);
+    font-size: var(--f-h3-font-size);
+    line-height: var(--f-h3-line-height);
+    letter-spacing: var(--f-h3-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h3--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h3--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h3---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h3---bold-weight, bold);
+    }
+  }
+  .f-h4 {
+    font-family: var(--f-h4-font-family);
+    font-weight: var(--f-h4-font-weight);
+    font-size: var(--f-h4-font-size);
+    line-height: var(--f-h4-line-height);
+    letter-spacing: var(--f-h4-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h4--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h4--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h4---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h4---bold-weight, bold);
+    }
+  }
+  .f-ui {
+    font-family: var(--f-ui-font-family);
+    font-weight: var(--f-ui-font-weight);
+    font-size: var(--f-ui-font-size);
+    line-height: var(--f-ui-line-height);
+    letter-spacing: var(--f-ui-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-ui--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-ui--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-ui---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-ui---bold-weight, bold);
+    }
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+  }
+  .text-balance {
+    text-wrap: balance;
+  }
+  .text-accent {
+    [class*="theme-"] & {
+      color: var(--text-accent, var(--color-blue-03));
+    }
+  }
+  .text-accent {
+    color: var(--color-blue-03);
+  }
+  .text-code {
+    [class*="theme-"] & {
+      color: var(--text-code, var(--color-black));
+    }
+  }
+  .text-code {
+    color: var(--color-black);
+  }
+  .text-code-example {
+    [class*="theme-"] & {
+      color: var(--text-code-example, var(--color-grey-3));
+    }
+  }
+  .text-code-example {
+    color: var(--color-grey-3);
+  }
+  .text-code-example-filename {
+    [class*="theme-"] & {
+      color: var(--text-code-example-filename, var(--color-blue-05));
+    }
+  }
+  .text-code-example-filename {
+    color: var(--color-blue-05);
+  }
+  .text-inverse {
+    [class*="theme-"] & {
+      color: var(--text-inverse, var(--color-white));
+    }
+  }
+  .text-inverse {
+    color: var(--color-white);
+  }
+  .text-primary {
+    [class*="theme-"] & {
+      color: var(--text-primary, var(--color-grey-90));
+    }
+  }
+  .text-primary {
+    color: var(--color-grey-90);
+  }
+  .text-title {
+    [class*="theme-"] & {
+      color: var(--text-title, var(--color-black));
+    }
+  }
+  .text-title {
+    color: var(--color-black);
+  }
+  .italic {
+    font-style: italic;
+  }
+  .not-italic {
+    font-style: normal;
+  }
+  .underline-border-primary {
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-grey-90);
+  }
+  .underline-border-secondary {
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-grey-30);
+  }
+  .underline-border-tertiary {
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-grey-54);
+  }
+  .underline-text-primary {
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-grey-90);
+  }
+  .underline-text-secondary {
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-grey-54);
+  }
+  .underline-dashed {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+  }
+  .underline-dotted {
+    text-decoration-line: underline;
+    text-decoration-style: dotted;
+  }
+  .underline-double {
+    text-decoration-line: underline;
+    text-decoration-style: double;
+  }
+  .underline-solid {
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+  }
+  .underline-wavy {
+    text-decoration-line: underline;
+    text-decoration-style: wavy;
+  }
+  .underline-thickness-1 {
+    text-decoration-line: underline;
+    text-decoration-thickness: 1px;
+  }
+  .underline-thickness-2 {
+    text-decoration-line: underline;
+    text-decoration-thickness: 2px;
+  }
+  .underline-thickness-4 {
+    text-decoration-line: underline;
+    text-decoration-thickness: 4px;
+  }
+  .underline-thickness-20 {
+    text-decoration-line: underline;
+    text-decoration-thickness: 20px;
+  }
+  .underline-thickness-auto {
+    text-decoration-line: underline;
+    text-decoration-thickness: auto;
+  }
+  .underline-thickness-from-font {
+    text-decoration-line: underline;
+    text-decoration-thickness: from-font;
+  }
+  .-underline-offset-1 {
+    text-decoration-line: underline;
+    text-underline-offset: calc(0.05em * -1);
+  }
+  .-underline-offset-2 {
+    text-decoration-line: underline;
+    text-underline-offset: calc(0.1em * -1);
+  }
+  .-underline-offset-20 {
+    text-decoration-line: underline;
+    text-underline-offset: calc(1em * -1);
+  }
+  .underline-offset-1 {
+    text-decoration-line: underline;
+    text-underline-offset: 0.05em;
+  }
+  .underline-offset-2 {
+    text-decoration-line: underline;
+    text-underline-offset: 0.1em;
+  }
+  .underline-offset-4 {
+    text-decoration-line: underline;
+    text-underline-offset: 0.2em;
+  }
+  .underline-offset-20 {
+    text-decoration-line: underline;
+    text-underline-offset: 1em;
+  }
+  .underline-skip-all {
+    text-decoration-line: underline;
+    text-decoration-skip-ink: all;
+  }
+  .underline-skip-auto {
+    text-decoration-line: underline;
+    text-decoration-skip-ink: auto;
+  }
+  .underline-skip-none {
+    text-decoration-line: underline;
+    text-decoration-skip-ink: none;
+  }
+  .underline {
+    text-decoration-line: underline;
+  }
+  .-underline-offset-1 {
+    text-underline-offset: calc(1px * -1);
+  }
+  .-underline-offset-2 {
+    text-underline-offset: calc(2px * -1);
+  }
+  .-underline-offset-20 {
+    text-underline-offset: calc(20px * -1);
+  }
+  .underline-offset-0 {
+    text-underline-offset: 0px;
+  }
+  .underline-offset-1 {
+    text-underline-offset: 1px;
+  }
+  .underline-offset-2 {
+    text-underline-offset: 2px;
+  }
+  .underline-offset-4 {
+    text-underline-offset: 4px;
+  }
+  .underline-offset-20 {
+    text-underline-offset: 20px;
+  }
+  .antialiased {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  .subpixel-antialiased {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+  }
+  .opacity-50 {
+    opacity: 50%;
+  }
+  .ring {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
+  .grayscale {
+    --tw-grayscale: grayscale(100%);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .ease-in-out {
+    --tw-ease: var(--ease-in-out);
+    transition-timing-function: var(--ease-in-out);
+  }
+  .content-\[\'\'\] {
+    --tw-content: '';
+    content: var(--tw-content);
+  }
+  .content-\[\'—\'\] {
+    --tw-content: '—';
+    content: var(--tw-content);
+  }
+  .content-\[close-quote\] {
+    --tw-content: close-quote;
+    content: var(--tw-content);
+  }
+  .content-\[open-quote\] {
+    --tw-content: open-quote;
+    content: var(--tw-content);
+  }
+  .background-fill-none {
+    &::before {
+      content: none;
+    }
+  }
+  .grid-cols-2 {
+    &.grid-line-x > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    &.grid-line-xfull > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    &.grid-line-x > *:nth-child(2n+1)::before {
+      --gridline-x-start: 0;
+    }
+    &.grid-line-xfull > *:nth-child(2n+1)::before {
+      --gridline-x-start: 0;
+    }
+    &.grid-line-x > *:nth-child(2n+2)::before {
+      --gridline-x-end: 0;
+    }
+    &.grid-line-xfull > *:nth-child(2n+2)::before {
+      --gridline-x-end: 0;
+    }
+    &.grid-line-x > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    &.grid-line-x > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+      --gridline-x-width: 0;
+    }
+    &.grid-line-x > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+      --gridline-x-width: 0;
+    }
+    &.grid-line-xfull > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    &.grid-line-xfull > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+      --gridline-x-width: 0;
+    }
+    &.grid-line-xfull > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+      --gridline-x-width: 0;
+    }
+    &[class*="grid-line-y"] > *:nth-child(n)::after {
+      --gridline-y-width: 1px;
+    }
+    &[class*="grid-line-y"] > *:nth-child(2n+2)::after {
+      --gridline-y-width: 0;
+    }
+    &.grid-line-y > *:nth-child(-n+2)::after {
+      --gridline-y-top: 0;
+    }
+    &.grid-line-yfull > *:nth-child(-n+2)::after {
+      --gridline-y-top: 0;
+    }
+    &.grid-line-y > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+      --gridline-y-bottom: 0;
+    }
+    &.grid-line-yfull > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-2& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+2)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-2& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-3& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+3)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-3& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-4& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+4)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-4& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-5& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+5)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-5& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-6& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+6)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-6& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-7& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+7)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-7& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-8& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+8)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-8& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-9& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+9)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-9& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-10& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+10)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-10& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-11& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+11)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-11& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-12& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+12)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-12& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-2& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-2& > *:nth-child(2n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+2)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-2& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-3& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-3& > *:nth-child(3n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+3)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-3& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-4& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-4& > *:nth-child(4n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+4)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-4& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-5& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-5& > *:nth-child(5n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+5)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-5& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-6& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-6& > *:nth-child(6n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+6)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-6& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-7& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-7& > *:nth-child(7n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+7)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-7& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-8& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-8& > *:nth-child(8n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+8)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-8& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-9& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-9& > *:nth-child(9n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+9)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-9& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-10& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-10& > *:nth-child(10n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+10)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-10& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-11& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-11& > *:nth-child(11n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+11)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-11& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-12& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-12& > *:nth-child(12n+1)::before {
+      --gridline-x-start: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+12)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-12& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x {
+    .grid-cols-1& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: 0;
+      --gridline-x-end: 0;
+    }
+    .grid-cols-1& > *:nth-child(1n+1)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-1& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-1& > *:nth-child(1n+1):nth-last-child(-n+1)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-1& > *:nth-child(1n+1):nth-last-child(-n+1) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-xfull {
+    .grid-cols-1& > *:nth-child(n)::before {
+      --gridline-x-width: 1px;
+      --gridline-x-start: calc(var(--inner-gutter) / -2);
+      --gridline-x-end: calc(var(--inner-gutter) / -2);
+    }
+    .grid-cols-1& > *:nth-child(1n+1)::before {
+      --gridline-x-end: 0;
+    }
+    .grid-cols-1& > *:nth-child(n):nth-last-child(n)::before {
+      --gridline-x-width: 1px;
+    }
+    .grid-cols-1& > *:nth-child(1n+1):nth-last-child(-n+1)::before {
+      --gridline-x-width: 0;
+    }
+    .grid-cols-1& > *:nth-child(1n+1):nth-last-child(-n+1) ~ *::before {
+      --gridline-x-width: 0;
+    }
+  }
+  .grid-line-x-24 {
+    & > *::before {
+      --gridline-x-bottom: -24px;
+      --gridline-y-top: -24px;
+      --gridline-y-bottom: -24px;
+    }
+    &.grid-line-yfull > *::after {
+      --gridline-x-bottom: -24px;
+      --gridline-y-top: -24px;
+      --gridline-y-bottom: -24px;
+    }
+  }
+  .grid-line-x-40 {
+    & > *::before {
+      --gridline-x-bottom: -40px;
+      --gridline-y-top: -40px;
+      --gridline-y-bottom: -40px;
+    }
+    &.grid-line-yfull > *::after {
+      --gridline-x-bottom: -40px;
+      --gridline-y-top: -40px;
+      --gridline-y-bottom: -40px;
+    }
+  }
+  .scrollbar-thin-collapse {
+    --scrollbar-width: 10px;
+    --scrollbar-padding: 2px;
+    --scrollbar-width: 6px;
+    --scrollbar-padding: 0px;
+    scrollbar-width: thin;
+  }
+  .scrollbar-thin {
+    --scrollbar-width: 10px;
+    --scrollbar-padding: 2px;
+    scrollbar-width: thin;
+  }
+  .grid-line-xy-primary {
+    & > *::before {
+      --gridline-x-color: var(--color-grey-90);
+    }
+    & > *::after {
+      --gridline-y-color: var(--color-grey-90);
+    }
+  }
+  .grid-line-xy-secondary {
+    & > *::before {
+      --gridline-x-color: var(--color-grey-30);
+    }
+    & > *::after {
+      --gridline-y-color: var(--color-grey-30);
+    }
+  }
+  .grid-line-y {
+    .grid-cols-2& > *:nth-child(-n+2)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-3& > *:nth-child(-n+3)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-4& > *:nth-child(-n+4)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-5& > *:nth-child(-n+5)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-6& > *:nth-child(-n+6)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-7& > *:nth-child(-n+7)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-8& > *:nth-child(-n+8)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-9& > *:nth-child(-n+9)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-10& > *:nth-child(-n+10)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-11& > *:nth-child(-n+11)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-y {
+    .grid-cols-12& > *:nth-child(-n+12)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-2& > *:nth-child(-n+2)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-3& > *:nth-child(-n+3)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-4& > *:nth-child(-n+4)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-5& > *:nth-child(-n+5)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-6& > *:nth-child(-n+6)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-7& > *:nth-child(-n+7)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-8& > *:nth-child(-n+8)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-9& > *:nth-child(-n+9)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-10& > *:nth-child(-n+10)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-11& > *:nth-child(-n+11)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .grid-line-yfull {
+    .grid-cols-12& > *:nth-child(-n+12)::after {
+      --gridline-y-top: 0;
+    }
+    .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12)::after {
+      --gridline-y-bottom: 0;
+    }
+  }
+  .keyline-0 {
+    --keyline-l-color: transparent;
+    --keyline-r-color: transparent;
+  }
+  .scrollbar-track-bg-column {
+    --scrollbar-bg: var(--color-blue-05);
+    --scrollbar-border: var(--scrollbar-bg);
+  }
+  .scrollbar-track-grey-15 {
+    --scrollbar-bg: var(--color-grey-15);
+    --scrollbar-border: var(--scrollbar-bg);
+  }
+  .scrollbar-track-primary {
+    --scrollbar-bg: var(--color-blue-06);
+    --scrollbar-border: var(--scrollbar-bg);
+  }
+  .w-cols-1 {
+    & > * {
+      --container-grid-columns: 1;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-2 {
+    & > * {
+      --container-grid-columns: 2;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-3 {
+    & > * {
+      --container-grid-columns: 3;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-4 {
+    & > * {
+      --container-grid-columns: 4;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-5 {
+    & > * {
+      --container-grid-columns: 5;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-6 {
+    & > * {
+      --container-grid-columns: 6;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-7 {
+    & > * {
+      --container-grid-columns: 7;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-8 {
+    & > * {
+      --container-grid-columns: 8;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-9 {
+    & > * {
+      --container-grid-columns: 9;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-10 {
+    & > * {
+      --container-grid-columns: 10;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-11 {
+    & > * {
+      --container-grid-columns: 11;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-12 {
+    & > * {
+      --container-grid-columns: 12;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-1 {
+    & > * {
+      --container-grid-columns: 1;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-2 {
+    & > * {
+      --container-grid-columns: 2;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-3 {
+    & > * {
+      --container-grid-columns: 3;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-4 {
+    & > * {
+      --container-grid-columns: 4;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-5 {
+    & > * {
+      --container-grid-columns: 5;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-6 {
+    & > * {
+      --container-grid-columns: 6;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-7 {
+    & > * {
+      --container-grid-columns: 7;
+      --cols-container: 0;
+    }
+  }
+  .w-cols-vw-8 {
+    & > * {
+      --container-grid-columns: 8;
+      --cols-container: 0;
+    }
+  }
+  .grid-line-x-primary {
+    & > *::before {
+      --gridline-x-color: var(--color-grey-90);
+    }
+  }
+  .grid-line-x-secondary {
+    & > *::before {
+      --gridline-x-color: var(--color-grey-30);
+    }
+  }
+  .grid-line-y-primary {
+    & > *::after {
+      --gridline-y-color: var(--color-grey-90);
+    }
+  }
+  .grid-line-y-quaternary {
+    & > *::after {
+      --gridline-y-color: var(--color-blue-05);
+    }
+  }
+  .grid-line-y-tertiary {
+    & > *::after {
+      --gridline-y-color: var(--color-grey-54);
+    }
+  }
+  .ratio-1x1 {
+    --ratio: 100%;
+  }
+  .ratio-16x9 {
+    --ratio: 56.25%;
+  }
+  .scrollbar-thumb-bg-column-alt {
+    --scrollbar-fg: var(--color-blue-04);
+  }
+  .scrollbar-thumb-primary {
+    --scrollbar-fg: var(--color-blue-03);
+  }
+  .scrollbar-thumb-red-01 {
+    --scrollbar-fg: var(--color-red-01);
+  }
+  .stroke-full-2 {
+    --stroke-full-thickness: 2px;
+  }
+  .stroke-full-4 {
+    --stroke-full-thickness: 4px;
+  }
+  .stroke-full-10 {
+    --stroke-full-thickness: 10px;
+  }
+  .stroke-full-dashed {
+    --stroke-full-style: dashed;
+  }
+  .stroke-full-dotted {
+    --stroke-full-style: dotted;
+  }
+  .stroke-full-primary {
+    --stroke-full-color: var(--color-grey-90);
+  }
+  .stroke-full-secondary {
+    --stroke-full-color: var(--color-grey-30);
+  }
+  .stroke-full-tertiary {
+    --stroke-full-color: var(--color-grey-54);
+  }
+  .marker\:content-\[\'⛄️\'\] {
+    & *::marker {
+      --tw-content: '⛄️';
+      content: var(--tw-content);
+    }
+    &::marker {
+      --tw-content: '⛄️';
+      content: var(--tw-content);
+    }
+    & *::-webkit-details-marker {
+      --tw-content: '⛄️';
+      content: var(--tw-content);
+    }
+    &::-webkit-details-marker {
+      --tw-content: '⛄️';
+      content: var(--tw-content);
+    }
+  }
+  .hover\:bg-secondary {
+    &:hover {
+      @media (hover: hover) {
+        [class*="theme-"] & {
+          background-color: var(--background-secondary, var(--color-grey-15));
+        }
+      }
+    }
+  }
+  .hover\:bg-secondary {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-grey-15);
+      }
+    }
+  }
+  .hover\:text-title {
+    &:hover {
+      @media (hover: hover) {
+        [class*="theme-"] & {
+          color: var(--text-title, var(--color-black));
+        }
+      }
+    }
+  }
+  .hover\:text-title {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-black);
+      }
+    }
+  }
+  .hover\:underline-border-primary {
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-line: underline;
+        text-decoration-color: var(--color-grey-90);
+      }
+    }
+  }
+  .hover\:opacity-100 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 100%;
+      }
+    }
+  }
+  .focus\:underline-border-secondary {
+    &:focus {
+      text-decoration-line: underline;
+      text-decoration-color: var(--color-grey-30);
+    }
+  }
+  .data-\[header-sticky\=true\]\:top-\[var\(--offset\)\] {
+    &[data-header-sticky="true"] {
+      top: var(--offset);
+    }
+  }
+  .data-\[header-sticky\=true\]\:data-\[header-reveal\=true\]\:top-0 {
+    &[data-header-sticky="true"] {
+      &[data-header-reveal="true"] {
+        top: calc(var(--spacing) * 0);
+      }
+    }
+  }
+  .sm\:mt-0 {
+    @media (width >= 544px) {
+      margin-top: calc(var(--spacing) * 0);
+    }
+  }
+  .sm\:mr-20 {
+    @media (width >= 544px) {
+      margin-right: calc(var(--spacing) * 20);
+    }
+  }
+  .sm\:mr-auto {
+    @media (width >= 544px) {
+      margin-right: auto;
+    }
+  }
+  .sm\:flex {
+    @media (width >= 544px) {
+      display: flex;
+    }
+  }
+  .sm\:w-cols-3 {
+    @media (width >= 544px) {
+      width: calc(((3 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (3 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .sm\:flex-row {
+    @media (width >= 544px) {
+      flex-direction: row;
+    }
+  }
+  .sm\:w-cols-3 {
+    @media (width >= 544px) {
+      & > * {
+        --container-grid-columns: 3;
+        --cols-container: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      & > * {
+        position: relative;
+      }
+      & > *::before {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::after {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::after {
+        content: "";
+        inset-inline-start: 0;
+        inset-inline-end: calc(var(--inner-gutter) / -2);
+        top: 0;
+        bottom: 0;
+        border-inline-start: 0 solid transparent;
+        border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+      }
+    }
+  }
+  .md\:keyline-l-primary {
+    @media (width >= 650px) {
+      position: relative;
+      --keyline-l-color: var(--color-grey-90);
+      --keyline-r-color: transparent;
+      &::before {
+        content: "";
+        position: absolute;
+        z-index: 0;
+        inset-inline-start: calc(var(--inner-gutter) / -2 - 1px);
+        inset-inline-end: calc(var(--inner-gutter) / -2);
+        top: 0;
+        bottom: 0;
+        border-left: 1px solid var(--keyline-l-color, transparent);
+        border-right: 1px solid var(--keyline-r-color, transparent);
+        pointer-events: none;
+      }
+    }
+  }
+  .md\:keyline-l-secondary {
+    @media (width >= 650px) {
+      position: relative;
+      --keyline-l-color: var(--color-grey-30);
+      --keyline-r-color: transparent;
+      &::before {
+        content: "";
+        position: absolute;
+        z-index: 0;
+        inset-inline-start: calc(var(--inner-gutter) / -2 - 1px);
+        inset-inline-end: calc(var(--inner-gutter) / -2);
+        top: 0;
+        bottom: 0;
+        border-left: 1px solid var(--keyline-l-color, transparent);
+        border-right: 1px solid var(--keyline-r-color, transparent);
+        pointer-events: none;
+      }
+    }
+  }
+  .md\:background-fill-accent {
+    @media (width >= 650px) {
+      --background-fill-bg: var(--color-blue-03);
+      position: relative;
+      &::before {
+        content: "";
+        position: absolute;
+        z-index: -1;
+        inset-inline-start: 50%;
+        top: 0;
+        bottom: 0;
+        width: 100vw;
+        margin-inline-start: -50vw;
+        background-color: var(--background-fill-bg, inherit);
+        pointer-events: none;
+      }
+    }
+  }
+  .md\:breakout-reset {
+    @media (width >= 650px) {
+      &[class] {
+        --breakout-outer-gutter: var(--outer-gutter);
+        --breakout-container-outer-gutter: 0;
+        position: unset;
+        inset-inline-start: unset;
+        width: unset;
+        margin-inline-start: unset;
+      }
+    }
+  }
+  .md\:grid-col-span-2 {
+    @media (width >= 650px) {
+      --container-grid-columns: 2;
+      grid-column: span 2 / span 2;
+    }
+  }
+  .md\:grid-col-span-4 {
+    @media (width >= 650px) {
+      --container-grid-columns: 4;
+      grid-column: span 4 / span 4;
+    }
+  }
+  .md\:mt-60 {
+    @media (width >= 650px) {
+      margin-top: calc(var(--spacing) * 60);
+    }
+  }
+  .md\:container-reset {
+    @media (width >= 650px) {
+      &[class] {
+        width: unset;
+        margin-right: unset;
+        margin-left: unset;
+      }
+      &[class] > * {
+        --container-outer-gutter: var(--outer-gutter, 0);
+        --breakout-container-outer-gutter: inherit;
+      }
+    }
+  }
+  .md\:full-bleed-scroller-reset {
+    @media (width >= 650px) {
+      display: unset;
+      flex-flow: unset;
+      flex-wrap: unset;
+      overflow-x: unset;
+      &::before {
+        content: none;
+        flex: unset;
+        width: unset;
+      }
+      &::after {
+        content: none;
+        flex: unset;
+        width: unset;
+      }
+    }
+  }
+  .md\:grid {
+    @media (width >= 650px) {
+      display: grid;
+    }
+  }
+  .md\:w-auto {
+    @media (width >= 650px) {
+      width: auto;
+    }
+  }
+  .md\:w-cols-1\/2 {
+    @media (width >= 650px) {
+      width: calc(50% - (var(--inner-gutter) * max(0.5, var(--cols-container, 0))));
+    }
+  }
+  .md\:w-cols-6 {
+    @media (width >= 650px) {
+      width: calc(((6 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (6 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .md\:grid-cols-2 {
+    @media (width >= 650px) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .md\:grid-cols-3 {
+    @media (width >= 650px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .md\:flex-row {
+    @media (width >= 650px) {
+      flex-direction: row;
+    }
+  }
+  .md\:gap-gutter {
+    @media (width >= 650px) {
+      grid-gap: var(--inner-gutter);
+      gap: var(--inner-gutter);
+    }
+  }
+  .md\:gap-x-gutter {
+    @media (width >= 650px) {
+      grid-column-gap: var(--inner-gutter);
+      column-gap: var(--inner-gutter);
+    }
+  }
+  .md\:gap-y-64 {
+    @media (width >= 650px) {
+      row-gap: calc(var(--spacing) * 64);
+    }
+  }
+  .md\:border-t-0 {
+    @media (width >= 650px) {
+      border-top-style: var(--tw-border-style);
+      border-top-width: 0px;
+    }
+  }
+  .md\:bg-accent {
+    @media (width >= 650px) {
+      [class*="theme-"] & {
+        background-color: var(--background-accent, var(--color-blue-03));
+      }
+    }
+  }
+  .md\:bg-accent {
+    @media (width >= 650px) {
+      background-color: var(--color-blue-03);
+    }
+  }
+  .md\:px-40 {
+    @media (width >= 650px) {
+      padding-inline: calc(var(--spacing) * 40);
+    }
+  }
+  .md\:pt-0 {
+    @media (width >= 650px) {
+      padding-top: calc(var(--spacing) * 0);
+    }
+  }
+  .md\:pt-80 {
+    @media (width >= 650px) {
+      padding-top: calc(var(--spacing) * 80);
+    }
+  }
+  .md\:f-code {
+    @media (width >= 650px) {
+      font-family: var(--f-code-font-family);
+      font-weight: var(--f-code-font-weight);
+      font-size: var(--f-code-font-size);
+      line-height: var(--f-code-line-height);
+      letter-spacing: var(--f-code-letter-spacing);
+      -moz-osx-font-smoothing: var(--f-code--moz-osx-font-smoothing);
+      -webkit-font-smoothing: var(--f-code--webkit-font-smoothing);
+      & b {
+        font-weight: var(--f-code---bold-weight, bold);
+      }
+      & strong {
+        font-weight: var(--f-code---bold-weight, bold);
+      }
+    }
+  }
+  .md\:grid-cols-2 {
+    @media (width >= 650px) {
+      &.grid-line-x > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: calc(var(--inner-gutter) / -2);
+        --gridline-x-end: calc(var(--inner-gutter) / -2);
+      }
+      &.grid-line-x > *:nth-child(2n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-xfull > *:nth-child(2n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-x > *:nth-child(2n+2)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(2n+2)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-x > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-x > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-x > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-xfull > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &[class*="grid-line-y"] > *:nth-child(n)::after {
+        --gridline-y-width: 1px;
+      }
+      &[class*="grid-line-y"] > *:nth-child(2n+2)::after {
+        --gridline-y-width: 0;
+      }
+      &.grid-line-y > *:nth-child(-n+2)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-yfull > *:nth-child(-n+2)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-y > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+        --gridline-y-bottom: 0;
+      }
+      &.grid-line-yfull > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-cols-3 {
+    @media (width >= 650px) {
+      &.grid-line-x > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: calc(var(--inner-gutter) / -2);
+        --gridline-x-end: calc(var(--inner-gutter) / -2);
+      }
+      &.grid-line-x > *:nth-child(3n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-xfull > *:nth-child(3n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-x > *:nth-child(3n+3)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(3n+3)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-x > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-x > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-x > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-xfull > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &[class*="grid-line-y"] > *:nth-child(n)::after {
+        --gridline-y-width: 1px;
+      }
+      &[class*="grid-line-y"] > *:nth-child(3n+3)::after {
+        --gridline-y-width: 0;
+      }
+      &.grid-line-y > *:nth-child(-n+3)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-yfull > *:nth-child(-n+3)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-y > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+        --gridline-y-bottom: 0;
+      }
+      &.grid-line-yfull > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-x-32 {
+    @media (width >= 650px) {
+      & > *::before {
+        --gridline-x-bottom: -32px;
+        --gridline-y-top: -32px;
+        --gridline-y-bottom: -32px;
+      }
+      &.grid-line-yfull > *::after {
+        --gridline-x-bottom: -32px;
+        --gridline-y-top: -32px;
+        --gridline-y-bottom: -32px;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-2& > *:nth-child(-n+2)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-3& > *:nth-child(-n+3)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-4& > *:nth-child(-n+4)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-5& > *:nth-child(-n+5)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-6& > *:nth-child(-n+6)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-7& > *:nth-child(-n+7)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-8& > *:nth-child(-n+8)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-9& > *:nth-child(-n+9)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-10& > *:nth-child(-n+10)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-11& > *:nth-child(-n+11)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:grid-line-y {
+    @media (width >= 650px) {
+      .grid-cols-12& > *:nth-child(-n+12)::after {
+        --gridline-y-top: 0;
+      }
+      .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .md\:keyline-0 {
+    @media (width >= 650px) {
+      --keyline-l-color: transparent;
+      --keyline-r-color: transparent;
+    }
+  }
+  .md\:keyline-l-0 {
+    @media (width >= 650px) {
+      --keyline-l-color: transparent;
+      --keyline-r-color: transparent;
+    }
+  }
+  .md\:keyline-r-0 {
+    @media (width >= 650px) {
+      --keyline-l-color: transparent;
+      --keyline-r-color: transparent;
+    }
+  }
+  .md\:w-cols-6 {
+    @media (width >= 650px) {
+      & > * {
+        --container-grid-columns: 6;
+        --cols-container: 0;
+      }
+    }
+  }
+  .md\:grid-line-x-primary {
+    @media (width >= 650px) {
+      & > *::before {
+        --gridline-x-color: var(--color-grey-90);
+      }
+    }
+  }
+  .md\:grid-line-x-quaternary {
+    @media (width >= 650px) {
+      & > *::before {
+        --gridline-x-color: var(--color-blue-05);
+      }
+    }
+  }
+  .md\:grid-line-x-tertiary {
+    @media (width >= 650px) {
+      & > *::before {
+        --gridline-x-color: var(--color-grey-54);
+      }
+    }
+  }
+  .md\:grid-line-y-primary {
+    @media (width >= 650px) {
+      & > *::after {
+        --gridline-y-color: var(--color-grey-90);
+      }
+    }
+  }
+  .md\:ratio-16x9 {
+    @media (width >= 650px) {
+      --ratio: 56.25%;
+    }
+  }
+  .md\:before\:hidden {
+    @media (width >= 650px) {
+      &::before {
+        content: var(--tw-content);
+        display: none;
+      }
+    }
+  }
+  .md\:after\:hidden {
+    @media (width >= 650px) {
+      &::after {
+        content: var(--tw-content);
+        display: none;
+      }
+    }
+  }
+  .lg\:keyline-l-secondary {
+    @media (width >= 990px) {
+      position: relative;
+      --keyline-l-color: var(--color-grey-30);
+      --keyline-r-color: transparent;
+      &::before {
+        content: "";
+        position: absolute;
+        z-index: 0;
+        inset-inline-start: calc(var(--inner-gutter) / -2 - 1px);
+        inset-inline-end: calc(var(--inner-gutter) / -2);
+        top: 0;
+        bottom: 0;
+        border-left: 1px solid var(--keyline-l-color, transparent);
+        border-right: 1px solid var(--keyline-r-color, transparent);
+        pointer-events: none;
+      }
+    }
+  }
+  .lg\:keyline-l-tertiary {
+    @media (width >= 990px) {
+      position: relative;
+      --keyline-l-color: var(--color-grey-54);
+      --keyline-r-color: transparent;
+      &::before {
+        content: "";
+        position: absolute;
+        z-index: 0;
+        inset-inline-start: calc(var(--inner-gutter) / -2 - 1px);
+        inset-inline-end: calc(var(--inner-gutter) / -2);
+        top: 0;
+        bottom: 0;
+        border-left: 1px solid var(--keyline-l-color, transparent);
+        border-right: 1px solid var(--keyline-r-color, transparent);
+        pointer-events: none;
+      }
+    }
+  }
+  .lg\:grid-line-x-0 {
+    @media (width >= 990px) {
+      & > * {
+        position: relative;
+      }
+      & > *::before {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::after {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::before {
+        content: none;
+      }
+    }
+  }
+  .lg\:grid-line-y-0 {
+    @media (width >= 990px) {
+      & > * {
+        position: relative;
+      }
+      & > *::before {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::after {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::after {
+        content: none;
+      }
+    }
+  }
+  .lg\:container {
+    @media (width >= 990px) {
+      &[class] {
+        width: calc(var(--container-width, 100%) - (2 * var(--breakout-container-outer-gutter, var(--container-outer-gutter, var(--outer-gutter, 0)))));
+        margin-right: auto;
+        margin-left: auto;
+      }
+      &[class] > * {
+        --container-outer-gutter: 0;
+        --breakout-container-outer-gutter: 0;
+      }
+      &[class] > .breakout[class] {
+        --breakout-outer-gutter: max(var(--outer-gutter), calc((100% - var(--container-width, 100%)) / 2));
+        --breakout-container-outer-gutter: var(--outer-gutter);
+        position: relative;
+        inset-inline-start: 50%;
+        width: calc(100vw - var(--scrollbar-visible-width, 0px));
+        margin-inline-start: calc((100vw - var(--scrollbar-visible-width, 0px)) / -2);
+      }
+    }
+  }
+  .lg\:breakout {
+    @media (width >= 990px) {
+      &[class] {
+        --breakout-outer-gutter: max(var(--outer-gutter), calc((100% - var(--container-width, 100%)) / 2));
+        --breakout-container-outer-gutter: var(--outer-gutter);
+        position: relative;
+        inset-inline-start: 50%;
+        width: calc(100vw - var(--scrollbar-visible-width, 0px));
+        margin-inline-start: calc((100vw - var(--scrollbar-visible-width, 0px)) / -2);
+      }
+      .container[class] > &[class] {
+        --breakout-outer-gutter: max(var(--outer-gutter), calc((100% - var(--container-width, 100%)) / 2));
+        --breakout-container-outer-gutter: var(--outer-gutter);
+        position: relative;
+        inset-inline-start: 50%;
+        width: calc(100vw - var(--scrollbar-visible-width, 0px));
+        margin-inline-start: calc((100vw - var(--scrollbar-visible-width, 0px)) / -2);
+      }
+      &[class].px-outer-gutter {
+        padding-inline-start: var(--breakout-outer-gutter);
+        padding-inline-end: var(--breakout-outer-gutter);
+      }
+      &[class] > .px-outer-gutter {
+        padding-inline-start: var(--breakout-outer-gutter);
+        padding-inline-end: var(--breakout-outer-gutter);
+      }
+      &[class].pr-outer-gutter {
+        padding-inline-end: var(--breakout-outer-gutter);
+      }
+      &[class] > .pr-outer-gutter {
+        padding-inline-end: var(--breakout-outer-gutter);
+      }
+      &[class].pl-outer-gutter {
+        padding-inline-start: var(--breakout-outer-gutter);
+      }
+      &[class] > .pl-outer-gutter {
+        padding-inline-start: var(--breakout-outer-gutter);
+      }
+      &[class] > .w-outer-gutter {
+        width: var(--breakout-outer-gutter);
+      }
+    }
+  }
+  .lg\:breakout-reset {
+    @media (width >= 990px) {
+      &[class] {
+        --breakout-outer-gutter: var(--outer-gutter);
+        --breakout-container-outer-gutter: 0;
+        position: unset;
+        inset-inline-start: unset;
+        width: unset;
+        margin-inline-start: unset;
+      }
+    }
+  }
+  .lg\:ratio-free {
+    @media (width >= 990px) {
+      &::before {
+        content: unset;
+      }
+      &::after {
+        content: unset;
+      }
+      & > [class*="ratio-content"] {
+        position: static;
+        left: auto;
+        right: auto;
+        top: auto;
+        bottom: auto;
+        width: auto;
+        height: auto;
+      }
+      & > [class*="ratio-content"][class*="w-full"] {
+        width: 100%;
+      }
+      & > [class*="ratio-content"][class*="h-auto"] {
+        height: auto;
+      }
+    }
+  }
+  .lg\:grid-col-span-4 {
+    @media (width >= 990px) {
+      --container-grid-columns: 4;
+      grid-column: span 4 / span 4;
+    }
+  }
+  .lg\:grid-col-span-6 {
+    @media (width >= 990px) {
+      --container-grid-columns: 6;
+      grid-column: span 6 / span 6;
+    }
+  }
+  .lg\:container {
+    @media (width >= 990px) {
+      width: 100%;
+      @media (width >= 0) {
+        max-width: 0;
+      }
+      @media (width >= 544px) {
+        max-width: 544px;
+      }
+      @media (width >= 650px) {
+        max-width: 650px;
+      }
+      @media (width >= 990px) {
+        max-width: 990px;
+      }
+      @media (width >= 1300px) {
+        max-width: 1300px;
+      }
+      @media (width >= 1520px) {
+        max-width: 1520px;
+      }
+    }
+  }
+  .lg\:mx-cols-1 {
+    @media (width >= 990px) {
+      margin-inline: calc(((((1 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (1 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+    }
+  }
+  .lg\:mx-cols-3 {
+    @media (width >= 990px) {
+      margin-inline: calc(((((3 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (3 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter)))) + var(--inner-gutter)));
+    }
+  }
+  .lg\:mt-outer-1 {
+    @media (width >= 990px) {
+      margin-top: var(--spacing-outer-1);
+    }
+  }
+  .lg\:container-reset {
+    @media (width >= 990px) {
+      &[class] {
+        width: unset;
+        margin-right: unset;
+        margin-left: unset;
+      }
+      &[class] > * {
+        --container-outer-gutter: var(--outer-gutter, 0);
+        --breakout-container-outer-gutter: inherit;
+      }
+    }
+  }
+  .lg\:w-1\/3 {
+    @media (width >= 990px) {
+      width: calc(1 / 3 * 100%);
+    }
+  }
+  .lg\:w-cols-1 {
+    @media (width >= 990px) {
+      width: calc(((1 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (1 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .lg\:w-cols-2\/3 {
+    @media (width >= 990px) {
+      width: calc(66.666% - (var(--inner-gutter) * max(0.333, var(--cols-container, 0))));
+    }
+  }
+  .lg\:w-cols-3 {
+    @media (width >= 990px) {
+      width: calc(((3 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (3 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .lg\:w-cols-10 {
+    @media (width >= 990px) {
+      width: calc(((10 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (10 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .lg\:w-cols-12 {
+    @media (width >= 990px) {
+      width: calc(((12 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (12 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .lg\:container {
+    @media (width >= 990px) {
+      max-width: 100%;
+    }
+  }
+  .lg\:grid-cols-3 {
+    @media (width >= 990px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .lg\:grid-cols-4 {
+    @media (width >= 990px) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .lg\:gap-x-0 {
+    @media (width >= 990px) {
+      column-gap: calc(var(--spacing) * 0);
+    }
+  }
+  .lg\:pt-100 {
+    @media (width >= 990px) {
+      padding-top: calc(var(--spacing) * 100);
+    }
+  }
+  .lg\:f-code {
+    @media (width >= 990px) {
+      font-family: var(--f-code-font-family);
+      font-weight: var(--f-code-font-weight);
+      font-size: var(--f-code-font-size);
+      line-height: var(--f-code-line-height);
+      letter-spacing: var(--f-code-letter-spacing);
+      -moz-osx-font-smoothing: var(--f-code--moz-osx-font-smoothing);
+      -webkit-font-smoothing: var(--f-code--webkit-font-smoothing);
+      & b {
+        font-weight: var(--f-code---bold-weight, bold);
+      }
+      & strong {
+        font-weight: var(--f-code---bold-weight, bold);
+      }
+    }
+  }
+  .lg\:f-h1 {
+    @media (width >= 990px) {
+      font-family: var(--f-h1-font-family);
+      font-weight: var(--f-h1-font-weight);
+      font-size: var(--f-h1-font-size);
+      line-height: var(--f-h1-line-height);
+      letter-spacing: var(--f-h1-letter-spacing);
+      -moz-osx-font-smoothing: var(--f-h1--moz-osx-font-smoothing);
+      -webkit-font-smoothing: var(--f-h1--webkit-font-smoothing);
+      & b {
+        font-weight: var(--f-h1---bold-weight, bold);
+      }
+      & strong {
+        font-weight: var(--f-h1---bold-weight, bold);
+      }
+    }
+  }
+  .lg\:underline-thickness-8 {
+    @media (width >= 990px) {
+      text-decoration-line: underline;
+      text-decoration-thickness: 8px;
+    }
+  }
+  .lg\:background-fill-none {
+    @media (width >= 990px) {
+      &::before {
+        content: none;
+      }
+    }
+  }
+  .lg\:grid-cols-3 {
+    @media (width >= 990px) {
+      &.grid-line-x > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: calc(var(--inner-gutter) / -2);
+        --gridline-x-end: calc(var(--inner-gutter) / -2);
+      }
+      &.grid-line-x > *:nth-child(3n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-xfull > *:nth-child(3n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-x > *:nth-child(3n+3)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(3n+3)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-x > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-x > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-x > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-xfull > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &[class*="grid-line-y"] > *:nth-child(n)::after {
+        --gridline-y-width: 1px;
+      }
+      &[class*="grid-line-y"] > *:nth-child(3n+3)::after {
+        --gridline-y-width: 0;
+      }
+      &.grid-line-y > *:nth-child(-n+3)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-yfull > *:nth-child(-n+3)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-y > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+        --gridline-y-bottom: 0;
+      }
+      &.grid-line-yfull > *:nth-child(3n+1):nth-last-child(-n+3)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .lg\:grid-cols-4 {
+    @media (width >= 990px) {
+      &.grid-line-x > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: calc(var(--inner-gutter) / -2);
+        --gridline-x-end: calc(var(--inner-gutter) / -2);
+      }
+      &.grid-line-x > *:nth-child(4n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-xfull > *:nth-child(4n+1)::before {
+        --gridline-x-start: 0;
+      }
+      &.grid-line-x > *:nth-child(4n+4)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-xfull > *:nth-child(4n+4)::before {
+        --gridline-x-end: 0;
+      }
+      &.grid-line-x > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-x > *:nth-child(4n+1):nth-last-child(-n+4)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-x > *:nth-child(4n+1):nth-last-child(-n+4) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      &.grid-line-xfull > *:nth-child(4n+1):nth-last-child(-n+4)::before {
+        --gridline-x-width: 0;
+      }
+      &.grid-line-xfull > *:nth-child(4n+1):nth-last-child(-n+4) ~ *::before {
+        --gridline-x-width: 0;
+      }
+      &[class*="grid-line-y"] > *:nth-child(n)::after {
+        --gridline-y-width: 1px;
+      }
+      &[class*="grid-line-y"] > *:nth-child(4n+4)::after {
+        --gridline-y-width: 0;
+      }
+      &.grid-line-y > *:nth-child(-n+4)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-yfull > *:nth-child(-n+4)::after {
+        --gridline-y-top: 0;
+      }
+      &.grid-line-y > *:nth-child(4n+1):nth-last-child(-n+4)::after {
+        --gridline-y-bottom: 0;
+      }
+      &.grid-line-yfull > *:nth-child(4n+1):nth-last-child(-n+4)::after {
+        --gridline-y-bottom: 0;
+      }
+    }
+  }
+  .lg\:keyline-l-0 {
+    @media (width >= 990px) {
+      --keyline-l-color: transparent;
+      --keyline-r-color: transparent;
+    }
+  }
+  .lg\:w-cols-1 {
+    @media (width >= 990px) {
+      & > * {
+        --container-grid-columns: 1;
+        --cols-container: 0;
+      }
+    }
+  }
+  .lg\:w-cols-3 {
+    @media (width >= 990px) {
+      & > * {
+        --container-grid-columns: 3;
+        --cols-container: 0;
+      }
+    }
+  }
+  .lg\:w-cols-10 {
+    @media (width >= 990px) {
+      & > * {
+        --container-grid-columns: 10;
+        --cols-container: 0;
+      }
+    }
+  }
+  .lg\:w-cols-12 {
+    @media (width >= 990px) {
+      & > * {
+        --container-grid-columns: 12;
+        --cols-container: 0;
+      }
+    }
+  }
+  .lg\:grid-line-y-secondary {
+    @media (width >= 990px) {
+      & > *::after {
+        --gridline-y-color: var(--color-grey-30);
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      & > * {
+        position: relative;
+      }
+      & > *::before {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::after {
+        position: absolute;
+        z-index: 0;
+        pointer-events: none;
+      }
+      & > *::before {
+        content: "";
+        inset-inline-start: var(--gridline-x-start, 0);
+        inset-inline-end: var(--gridline-x-end, 0);
+        top: 0;
+        bottom: var(--gridline-x-bottom, calc(var(--inner-gutter) / -2));
+        border-top: 0 solid transparent;
+        border-bottom: var(--gridline-x-width, 0) solid var(--gridline-x-color, transparent);
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-line-yfull& > *::after {
+        inset-inline-start: 0;
+        inset-inline-end: calc(var(--inner-gutter) / -2);
+        top: var(--gridline-y-top, calc(var(--inner-gutter) / -2));
+        bottom: var(--gridline-y-bottom, calc(var(--inner-gutter) / -2));
+        border-inline-start: 0 solid transparent;
+        border-inline-end: var(--gridline-y-width, 0) solid var(--gridline-y-color, transparent);
+      }
+    }
+  }
+  .xl\:w-cols-1\/2 {
+    @media (width >= 1300px) {
+      width: calc(50% - (var(--inner-gutter) * max(0.5, var(--cols-container, 0))));
+    }
+  }
+  .xl\:w-cols-8 {
+    @media (width >= 1300px) {
+      width: calc(((8 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (8 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .xl\:gap-x-gutter {
+    @media (width >= 1300px) {
+      grid-column-gap: var(--inner-gutter);
+      column-gap: var(--inner-gutter);
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-2& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-2& > *:nth-child(2n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-2& > *:nth-child(2n+2)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-2& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-2& > *:nth-child(2n+1):nth-last-child(-n+2) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-3& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-3& > *:nth-child(3n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-3& > *:nth-child(3n+3)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-3& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-3& > *:nth-child(3n+1):nth-last-child(-n+3) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-4& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-4& > *:nth-child(4n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-4& > *:nth-child(4n+4)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-4& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-4& > *:nth-child(4n+1):nth-last-child(-n+4) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-5& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-5& > *:nth-child(5n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-5& > *:nth-child(5n+5)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-5& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-5& > *:nth-child(5n+1):nth-last-child(-n+5) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-6& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-6& > *:nth-child(6n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-6& > *:nth-child(6n+6)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-6& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-6& > *:nth-child(6n+1):nth-last-child(-n+6) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-7& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-7& > *:nth-child(7n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-7& > *:nth-child(7n+7)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-7& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-7& > *:nth-child(7n+1):nth-last-child(-n+7) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-8& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-8& > *:nth-child(8n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-8& > *:nth-child(8n+8)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-8& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-8& > *:nth-child(8n+1):nth-last-child(-n+8) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-9& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-9& > *:nth-child(9n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-9& > *:nth-child(9n+9)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-9& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-9& > *:nth-child(9n+1):nth-last-child(-n+9) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-10& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-10& > *:nth-child(10n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-10& > *:nth-child(10n+10)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-10& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-10& > *:nth-child(10n+1):nth-last-child(-n+10) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-11& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-11& > *:nth-child(11n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-11& > *:nth-child(11n+11)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-11& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-11& > *:nth-child(11n+1):nth-last-child(-n+11) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-12& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-12& > *:nth-child(12n+1)::before {
+        --gridline-x-start: 0;
+      }
+      .grid-cols-12& > *:nth-child(12n+12)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-12& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-12& > *:nth-child(12n+1):nth-last-child(-n+12) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x {
+    @media (width >= 1300px) {
+      .grid-cols-1& > *:nth-child(n)::before {
+        --gridline-x-width: 1px;
+        --gridline-x-start: 0;
+        --gridline-x-end: 0;
+      }
+      .grid-cols-1& > *:nth-child(1n+1)::before {
+        --gridline-x-end: 0;
+      }
+      .grid-cols-1& > *:nth-child(n):nth-last-child(n)::before {
+        --gridline-x-width: 1px;
+      }
+      .grid-cols-1& > *:nth-child(1n+1):nth-last-child(-n+1)::before {
+        --gridline-x-width: 0;
+      }
+      .grid-cols-1& > *:nth-child(1n+1):nth-last-child(-n+1) ~ *::before {
+        --gridline-x-width: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x-32 {
+    @media (width >= 1300px) {
+      & > *::before {
+        --gridline-x-bottom: -32px;
+        --gridline-y-top: -32px;
+        --gridline-y-bottom: -32px;
+      }
+      &.grid-line-yfull > *::after {
+        --gridline-x-bottom: -32px;
+        --gridline-y-top: -32px;
+        --gridline-y-bottom: -32px;
+      }
+    }
+  }
+  .xl\:w-cols-8 {
+    @media (width >= 1300px) {
+      & > * {
+        --container-grid-columns: 8;
+        --cols-container: 0;
+      }
+    }
+  }
+  .xl\:grid-line-x-primary {
+    @media (width >= 1300px) {
+      & > *::before {
+        --gridline-x-color: var(--color-grey-90);
+      }
+    }
+  }
+  .xxl\:w-cols-6 {
+    @media (width >= 1520px) {
+      width: calc(((6 / var(--container-grid-columns, var(--grid-columns))) * (100% - (var(--inner-gutter) * var(--cols-container, 0)))) - (var(--inner-gutter) - (6 / var(--container-grid-columns, var(--grid-columns)) * var(--inner-gutter))));
+    }
+  }
+  .xxl\:w-cols-6 {
+    @media (width >= 1520px) {
+      & > * {
+        --container-grid-columns: 6;
+        --cols-container: 0;
+      }
+    }
+  }
+  .hover-hover\:bg-column-alt {
+    @media (hover: hover) {
+      [class*="theme-"] & {
+        background-color: var(--background-column-alt, var(--color-blue-04));
+      }
+    }
+  }
+  .hover-hover\:bg-column-alt {
+    @media (hover: hover) {
+      background-color: var(--color-blue-04);
+    }
+  }
+}
+@layer components {
+  .show-grid {
+    --grid-column-bg: rgba(0, 0, 0, 0.05);
+    position: relative;
+    &::after {
+      position: fixed;
+      z-index: 1;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
+      top: 0;
+      bottom: 0;
+      width: calc(var(--container-width, 100%) - (2 * var(--outer-gutter, 0)));;
+      height: 100%;
+      margin: 0 auto;
+      background: repeating-linear-gradient(
+        90deg,
+        var(--grid-column-bg),
+        var(--grid-column-bg) calc((100% - (((var(--grid-columns) - 1) * var(--inner-gutter)))) / var(--grid-columns)),
+        rgba(0,0,0,0) calc((100% - (((var(--grid-columns) - 1) * var(--inner-gutter)))) / var(--grid-columns)),
+        rgba(0,0,0,0) calc((100% - (((var(--grid-columns) - 1) * var(--inner-gutter)))) / var(--grid-columns) + var(--inner-gutter))
+      );
+      pointer-events: none;
+      position: absolute;
+      width: 100%;
+      --tw-content: '';
+      content: var(--tw-content);
+    }
+  }
+  .blockquote {
+    [class*="theme-"] & {
+      background-color: var(--background-quote, var(--color-grey-5));
+    }
+    background-color: var(--color-grey-5);
+    padding-block: calc(var(--spacing) * 20);
+  }
+  .blockquote blockquote {
+    display: block;
+    padding-inline: calc(var(--spacing) * 20);
+    @media (width >= 650px) {
+      padding-inline: calc(var(--spacing) * 40);
+    }
+  }
+  .blockquote blockquote p {
+    font-style: italic;
+  }
+  .blockquote blockquote p:first-child {
+    position: relative;
+    margin-top: calc(var(--spacing) * 0);
+  }
+  .blockquote blockquote p:first-child::before {
+    content: open-quote;
+    position: absolute;
+    top: calc(var(--spacing) * 0);
+    right: 100%;
+    left: calc(var(--spacing) * -8);
+  }
+  .blockquote blockquote p:last-child::after {
+    content: close-quote;
+  }
+  .blockquote figcaption {
+    margin-top: calc(var(--spacing) * 8);
+    display: block;
+    padding-inline: calc(var(--spacing) * 20);
+    @media (width >= 650px) {
+      padding-inline: calc(var(--spacing) * 40);
+    }
+  }
+  .blockquote cite {
+    font-style: normal;
+  }
+  .blockquote cite::before {
+    content: '—';
+    margin-right: calc(var(--spacing) * 8);
+  }
+  .code-example {
+    display: block;
+    [class*="theme-"] & {
+      background-color: var(--background-code-example, var(--color-grey-90));
+    }
+    background-color: var(--color-grey-90);
+  }
+  .code-example .code-example-filename {
+    display: inline-block;
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+    [class*="theme-"] & {
+      border-color: var(--border-code-example-filename, var(--color-blue-05));
+    }
+    border-color: var(--color-blue-05);
+    padding-inline: calc(var(--spacing) * 20);
+    padding-block: calc(var(--spacing) * 12);
+    font-family: var(--f-ui-font-family);
+    font-weight: var(--f-ui-font-weight);
+    font-size: var(--f-ui-font-size);
+    line-height: var(--f-ui-line-height);
+    letter-spacing: var(--f-ui-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-ui--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-ui--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-ui---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-ui---bold-weight, bold);
+    }
+    [class*="theme-"] & {
+      color: var(--text-code-example-filename, var(--color-blue-05));
+    }
+    color: var(--color-blue-05);
+    [class*="theme-"] & {
+      color: var(--text-inverse, var(--color-white));
+    }
+    color: var(--color-white);
+    min-width: 160px;
+  }
+  .code-example .code-example-code {
+    display: block;
+    [class*="theme-"] & {
+      background-color: var(--background-code-example, var(--color-grey-90));
+    }
+    background-color: var(--color-grey-90);
+    font-family: var(--f-code-font-family);
+    font-weight: var(--f-code-font-weight);
+    font-size: var(--f-code-font-size);
+    line-height: var(--f-code-line-height);
+    letter-spacing: var(--f-code-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-code--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-code--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+    [class*="theme-"] & {
+      color: var(--text-code-example, var(--color-grey-3));
+    }
+    color: var(--color-grey-3);
+  }
+  .code-example .code-example-code code {
+    max-height: calc(var(--spacing) * 600);
+    overflow: auto;
+    [class*="theme-"] & {
+      background-color: var(--background-code-example, var(--color-grey-90));
+    }
+    background-color: var(--color-grey-90);
+    scrollbar-color: var(--grey-54) var(--grey-90);
+    scrollbar-width: thin;
+  }
+  .code-example .code-example-code code::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  .code-example .code-example-code code::-webkit-scrollbar-track {
+    background: var(--grey-90);
+  }
+  .code-example .code-example-code code::-webkit-scrollbar-thumb {
+    background: var(--grey-54);
+    width: 8px;
+    height: 8px;
+  }
+  .copy h2 {
+    font-family: var(--f-h2-font-family);
+    font-weight: var(--f-h2-font-weight);
+    font-size: var(--f-h2-font-size);
+    line-height: var(--f-h2-line-height);
+    letter-spacing: var(--f-h2-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h2--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h2--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h2---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h2---bold-weight, bold);
+    }
+  }
+  .copy h2:not(:first-child) {
+    margin-top: calc(var(--spacing) * 56);
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+    [class*="theme-"] & {
+      border-color: var(--border-secondary, var(--color-grey-30));
+    }
+    border-color: var(--color-grey-30);
+    padding-top: calc(var(--spacing) * 48);
+  }
+  .copy h3 {
+    margin-top: calc(var(--spacing) * 40);
+    font-family: var(--f-h3-font-family);
+    font-weight: var(--f-h3-font-weight);
+    font-size: var(--f-h3-font-size);
+    line-height: var(--f-h3-line-height);
+    letter-spacing: var(--f-h3-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h3--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h3--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h3---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h3---bold-weight, bold);
+    }
+  }
+  .copy h4 {
+    margin-top: calc(var(--spacing) * 40);
+    font-family: var(--f-h4-font-family);
+    font-weight: var(--f-h4-font-weight);
+    font-size: var(--f-h4-font-size);
+    line-height: var(--f-h4-line-height);
+    letter-spacing: var(--f-h4-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-h4--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-h4--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-h4---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-h4---bold-weight, bold);
+    }
+  }
+  .copy p {
+    margin-top: calc(var(--spacing) * 20);
+    font-family: var(--f-body-font-family);
+    font-weight: var(--f-body-font-weight);
+    font-size: var(--f-body-font-size);
+    line-height: var(--f-body-line-height);
+    letter-spacing: var(--f-body-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-body--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-body--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+  }
+  .copy p:first-child {
+    margin-top: calc(var(--spacing) * 0);
+  }
+  .copy ul {
+    margin-top: calc(var(--spacing) * 20);
+    list-style-type: disc;
+    padding-left: calc(var(--spacing) * 16);
+    font-family: var(--f-body-font-family);
+    font-weight: var(--f-body-font-weight);
+    font-size: var(--f-body-font-size);
+    line-height: var(--f-body-line-height);
+    letter-spacing: var(--f-body-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-body--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-body--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+  }
+  .copy ul ul {
+    margin-top: calc(var(--spacing) * 0);
+  }
+  .copy ol {
+    margin-top: calc(var(--spacing) * 20);
+    list-style-type: decimal;
+    padding-left: calc(var(--spacing) * 16);
+    font-family: var(--f-body-font-family);
+    font-weight: var(--f-body-font-weight);
+    font-size: var(--f-body-font-size);
+    line-height: var(--f-body-line-height);
+    letter-spacing: var(--f-body-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-body--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-body--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-body---bold-weight, bold);
+    }
+  }
+  .copy .code-example {
+    margin-top: calc(var(--spacing) * 20);
+  }
+  .copy code:not([class]) {
+    [class*="theme-"] & {
+      background-color: var(--background-code, var(--color-white));
+    }
+    background-color: var(--color-white);
+    padding-inline: calc(var(--spacing) * 8);
+    padding-top: calc(var(--spacing) * 4);
+    padding-bottom: calc(var(--spacing) * 2);
+    font-family: var(--f-code-font-family);
+    font-weight: var(--f-code-font-weight);
+    font-size: var(--f-code-font-size);
+    line-height: var(--f-code-line-height);
+    letter-spacing: var(--f-code-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-code--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-code--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+    [class*="theme-"] & {
+      color: var(--text-code, var(--color-black));
+    }
+    color: var(--color-black);
+  }
+  .copy pre:not([class]) {
+    margin-top: calc(var(--spacing) * 20);
+    display: block;
+    max-height: calc(var(--spacing) * 400);
+    overflow-y: scroll;
+    font-family: var(--f-code-font-family);
+    font-weight: var(--f-code-font-weight);
+    font-size: var(--f-code-font-size);
+    line-height: var(--f-code-line-height);
+    letter-spacing: var(--f-code-letter-spacing);
+    -moz-osx-font-smoothing: var(--f-code--moz-osx-font-smoothing);
+    -webkit-font-smoothing: var(--f-code--webkit-font-smoothing);
+    & b {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+    & strong {
+      font-weight: var(--f-code---bold-weight, bold);
+    }
+  }
+  .copy pre:not([class]) code:not([class]) {
+    display: block;
+    padding: calc(var(--spacing) * 8);
+  }
+  .copy a {
+    [class*="theme-"] & {
+      color: var(--text-accent, var(--color-blue-03));
+    }
+    color: var(--color-blue-03);
+    text-decoration-line: underline;
+  }
+  .copy a:hover, .copy a:focus {
+    [class*="theme-"] & {
+      color: var(--text-primary, var(--color-grey-90));
+    }
+    color: var(--color-grey-90);
+  }
+  .copy hr {
+    margin-block: calc(var(--spacing) * 40);
+    [class*="theme-"] & {
+      border-color: var(--border-secondary, var(--color-grey-30));
+    }
+    border-color: var(--color-grey-30);
+  }
+  .copy .blockquote {
+    margin-top: calc(var(--spacing) * 20);
+  }
+  @media (min-width: 768px) {
+    .copy > *:not(.code-example, h2, hr) {
+      max-width: 80%;
+    }
+  }
+  @media (min-width: 1024px) {
+    .copy > *:not(.code-example, h2, hr) {
+      max-width: 60%;
+    }
+  }
+  .copy table {
+    margin-top: calc(var(--spacing) * 20);
+  }
+  .copy th, .copy td {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 1px;
+    [class*="theme-"] & {
+      border-color: var(--border-secondary, var(--color-grey-30));
+    }
+    border-color: var(--color-grey-30);
+    padding-inline: calc(var(--spacing) * 10);
+    padding-bottom: calc(var(--spacing) * 4);
+  }
+  .copy th:first-child, .copy td:first-child {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 0px;
+    padding-inline-start: calc(var(--spacing) * 0);
+  }
+  .copy th:last-child, .copy td:last-child {
+    padding-inline-end: calc(var(--spacing) * 0);
+  }
+}
+@layer base {
+  :root {
+    --breakpoint: "xs";
+    --container-width: unset;
+    --inner-gutter: 10px;
+    --outer-gutter: 20px;
+    --grid-columns: 4;
+    --env: "dev";
+    --grid-column-bg: rgba(127, 255, 255, 0.25);
+  }
+  @media (width >= 544px) {
+    :root {
+      --breakpoint: "sm";
+      --container-width: unset;
+      --inner-gutter: 15px;
+      --outer-gutter: 30px;
+      --grid-columns: 4;
+    }
+  }
+  @media (width >= 650px) {
+    :root {
+      --breakpoint: "md";
+      --container-width: unset;
+      --inner-gutter: 20px;
+      --outer-gutter: 40px;
+      --grid-columns: 8;
+    }
+  }
+  @media (width >= 990px) {
+    :root {
+      --breakpoint: "lg";
+      --container-width: unset;
+      --inner-gutter: 30px;
+      --outer-gutter: 40px;
+      --grid-columns: 12;
+    }
+  }
+  @media (width >= 1300px) {
+    :root {
+      --breakpoint: "xl";
+      --container-width: unset;
+      --inner-gutter: 40px;
+      --outer-gutter: 40px;
+      --grid-columns: 12;
+    }
+  }
+  @media (width >= 1520px) {
+    :root {
+      --breakpoint: "xxl";
+      --container-width: 1440px;
+      --inner-gutter: 40px;
+      --outer-gutter: 0px;
+      --grid-columns: 12;
+    }
+  }
+}
+@layer base {
+  :root {
+    --color-white: #fff;
+    --color-grey-3: #f8f8f8;
+    --color-grey-5: #f2f2f2;
+    --color-grey-10: #e6e6e6;
+    --color-grey-15: #d9d9d9;
+    --color-grey-30: #b3b3b3;
+    --color-grey-54: #757575;
+    --color-grey-90: #1a1a1a;
+    --color-black: #000;
+    --color-blue-01: #0A152B;
+    --color-blue-02: #001F5C;
+    --color-blue-03: #004F91;
+    --color-blue-04: #313BFB;
+    --color-blue-05: #81EEF3;
+    --color-blue-06: #ADD8E6;
+    --color-red-01: #f00;
+    --color-green-10: #F3F7F5;
+    --color-green-20: #E6F4EF;
+    --color-green-30: #CDE9DE;
+    --color-green-40: #9FD8C3;
+    --color-green-50: #4CBF99;
+    --color-green-60: #158F6A;
+    --color-green-70: #1F6F54;
+    --color-green-90: #0B3D2E;
+    --color-purple-10: #F8F5FC;
+    --color-purple-20: #F4EFFB;
+    --color-purple-30: #E7DDF7;
+    --color-purple-40: #D1C4EE;
+    --color-purple-50: #A78BDA;
+    --color-purple-60: #7A57B8;
+    --color-purple-70: #5B3A8A;
+    --color-purple-90: #3A1F5D;
+  }
+}
+@layer base {
+  :root {
+    --font-sans: SuisseIntl, Helvetica, Arial, sans-serif;
+    --font-serif: "Times New Roman", Georgia, serif;
+    --font-mono: "Lucida Console", Courier, monospace;
+    --f-h1-font-family: var(--font-sans);
+    --f-h1-font-weight: 500;
+    --f-h1-font-size: 2rem;
+    --f-h1-line-height: 1.2;
+    --f-h1-letter-spacing: -0.02em;
+    --f-h1--moz-osx-font-smoothing: grayscale;
+    --f-h1--webkit-font-smoothing: antialiased;
+    --f-h1---bold-weight: 500;
+    --f-h2-font-family: var(--font-sans);
+    --f-h2-font-weight: 500;
+    --f-h2-font-size: 1.25rem;
+    --f-h2-line-height: 1.2;
+    --f-h2-letter-spacing: -0.02em;
+    --f-h2--moz-osx-font-smoothing: grayscale;
+    --f-h2--webkit-font-smoothing: antialiased;
+    --f-h2---bold-weight: 500;
+    --f-h3-font-family: var(--font-sans);
+    --f-h3-font-weight: 500;
+    --f-h3-font-size: 1rem;
+    --f-h3-line-height: 1.2;
+    --f-h3-letter-spacing: -0.02em;
+    --f-h3--moz-osx-font-smoothing: grayscale;
+    --f-h3--webkit-font-smoothing: antialiased;
+    --f-h3---bold-weight: 500;
+    --f-h4-font-family: var(--font-sans);
+    --f-h4-font-weight: 600;
+    --f-h4-font-size: 0.875rem;
+    --f-h4-line-height: 1.2;
+    --f-h4-letter-spacing: -0.02em;
+    --f-h4--moz-osx-font-smoothing: grayscale;
+    --f-h4--webkit-font-smoothing: antialiased;
+    --f-h4---bold-weight: 600;
+    --f-body-font-family: var(--font-sans);
+    --f-body-font-size: 0.875rem;
+    --f-body-line-height: 1.7;
+    --f-body--moz-osx-font-smoothing: grayscale;
+    --f-body--webkit-font-smoothing: antialiased;
+    --f-body---bold-weight: 600;
+    --f-ui-font-family: var(--font-sans);
+    --f-ui-font-size: 0.75rem;
+    --f-ui-line-height: 1.2;
+    --f-ui-font-weight: 400;
+    --f-code-font-family: var(--font-mono);
+    --f-code-font-size: 0.875rem;
+    --f-code-line-height: 1.2;
+    --f-code-font-weight: 400;
+  }
+  @media (width >= 650px) {
+    :root {
+      --f-h1-font-size: 2.25rem;
+      --f-h2-font-size: 1.5rem;
+      --f-h3-font-size: 1.25rem;
+      --f-h4-font-size: 1rem;
+      --f-body-font-size: 1rem;
+    }
+  }
+  @media (width >= 990px) {
+    :root {
+      --f-h1-font-size: 3rem;
+      --f-h2-font-size: 1.75rem;
+    }
+  }
+}
+@layer base {
+  :root {
+    --spacing-outer-1: 4rem;
+    --spacing-inner-1: 1.5rem;
+    --spacing-inner-2: 1rem;
+  }
+  @media (width >= 650px) {
+    :root {
+      --spacing-inner-1: 2.5rem;
+      --spacing-inner-2: 1.5rem;
+    }
+  }
+  @media (width >= 990px) {
+    :root {
+      --spacing-outer-1: 6rem;
+      --spacing-inner-1: 4rem;
+      --spacing-inner-2: 2rem;
+    }
+  }
+}
+@layer base {
+  :root {
+    --white: #fff;
+    --grey-3: #f8f8f8;
+    --grey-5: #f2f2f2;
+    --grey-10: #e6e6e6;
+    --grey-15: #d9d9d9;
+    --grey-30: #b3b3b3;
+    --grey-54: #757575;
+    --grey-90: #1a1a1a;
+    --black: #000;
+    --blue-01: #0A152B;
+    --blue-02: #001F5C;
+    --blue-03: #004F91;
+    --blue-04: #313BFB;
+    --blue-05: #81EEF3;
+    --blue-06: #ADD8E6;
+    --red-01: #f00;
+    --green-10: #F3F7F5;
+    --green-20: #E6F4EF;
+    --green-30: #CDE9DE;
+    --green-40: #9FD8C3;
+    --green-50: #4CBF99;
+    --green-60: #158F6A;
+    --green-70: #1F6F54;
+    --green-90: #0B3D2E;
+    --purple-10: #F8F5FC;
+    --purple-20: #F4EFFB;
+    --purple-30: #E7DDF7;
+    --purple-40: #D1C4EE;
+    --purple-50: #A78BDA;
+    --purple-60: #7A57B8;
+    --purple-70: #5B3A8A;
+    --purple-90: #3A1F5D;
+  }
+  .theme-accent-1 {
+    --text-title: var(--green-90);
+    --text-primary: var(--green-90);
+    --text-secondary: var(--green-70);
+    --text-accent: var(--green-60);
+    --background-primary: var(--green-20);
+    --background-secondary: var(--green-30);
+    --background-inverse: var(--green-90);
+    --background-accent: var(--green-10);
+    --border-primary: var(--green-50);
+    --border-secondary: var(--green-40);
+  }
+  .theme-accent-2 {
+    --text-title: var(--purple-90);
+    --text-primary: var(--purple-90);
+    --text-secondary: var(--purple-70);
+    --text-accent: var(--purple-60);
+    --background-primary: var(--purple-20);
+    --background-secondary: var(--purple-30);
+    --background-accent: var(--purple-10);
+    --border-primary: var(--purple-50);
+    --border-secondary: var(--purple-40);
+  }
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-sepia {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-drop-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-drop-shadow-size {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ease {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-content {
+  syntax: "*";
+  inherits: false;
+  initial-value: "";
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
+    *, ::before, ::after, ::backdrop {
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
+      --tw-border-style: solid;
+      --tw-font-weight: initial;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
+      --tw-blur: initial;
+      --tw-brightness: initial;
+      --tw-contrast: initial;
+      --tw-grayscale: initial;
+      --tw-hue-rotate: initial;
+      --tw-invert: initial;
+      --tw-opacity: initial;
+      --tw-saturate: initial;
+      --tw-sepia: initial;
+      --tw-drop-shadow: initial;
+      --tw-drop-shadow-color: initial;
+      --tw-drop-shadow-alpha: 100%;
+      --tw-drop-shadow-size: initial;
+      --tw-ease: initial;
+      --tw-content: "";
+    }
+  }
+}

--- a/docs/tailwind.css
+++ b/docs/tailwind.css
@@ -1540,6 +1540,9 @@
   .flex-none {
     flex: none;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .flex-shrink-0 {
     flex-shrink: 0;
   }
@@ -1551,6 +1554,9 @@
   }
   .grow {
     flex-grow: 1;
+  }
+  .border-collapse {
+    border-collapse: collapse;
   }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
@@ -2029,6 +2035,9 @@
   .text-balance {
     text-wrap: balance;
   }
+  .text-wrap {
+    text-wrap: wrap;
+  }
   .text-accent {
     [class*="theme-"] & {
       color: var(--text-accent, var(--color-blue-03));
@@ -2243,6 +2252,9 @@
   }
   .grayscale {
     --tw-grayscale: grayscale(100%);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .transition {
@@ -5476,6 +5488,37 @@
     --purple-60: #7A57B8;
     --purple-70: #5B3A8A;
     --purple-90: #3A1F5D;
+  }
+  .theme-reset {
+    --text-title: var(--color-black);
+    --text-primary: var(--color-grey-90);
+    --text-inverse: var(--color-white);
+    --text-secondary: var(--color-grey-54);
+    --text-accent: var(--color-blue-03);
+    --text-code: var(--color-black);
+    --text-code-example: var(--color-grey-3);
+    --text-code-example-filename: var(--color-blue-05);
+    --text-error: var(--color-red-01);
+    --background-primary: var(--color-grey-10);
+    --background-header: var(--color-grey-10);
+    --background-container-demo: var(--color-white);
+    --background-footer: var(--color-grey-10);
+    --background-banner: var(--color-grey-90);
+    --background-accent: var(--color-blue-03);
+    --background-column: var(--color-blue-05);
+    --background-column-alt: var(--color-blue-04);
+    --background-code: var(--color-white);
+    --background-code-example: var(--color-grey-90);
+    --background-quote: var(--color-grey-5);
+    --background-secondary: var(--color-grey-15);
+    --background-inverse: var(--color-black);
+    --border-primary: var(--color-grey-90);
+    --border-secondary: var(--color-grey-30);
+    --border-tertiary: var(--color-grey-54);
+    --border-quaternary: var(--color-blue-05);
+    --border-code-example-filename: var(--color-blue-05);
+    --underline-primary: var(--color-grey-54);
+    --underline-secondary: var(--color-blue-03);
   }
   .theme-accent-1 {
     --text-title: var(--green-90);

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const FullBleedScroller = require('./src/FullBleedScroller');
 const InteractionMediaQueries = require('./src/InteractionMediaQueries');
 const Scrollbar = require('./src/Scrollbar');
 const StrokeFull = require('./src/StrokeFull');
+const ColorThemes = require('./src/ColorThemes');
 
 module.exports = {
   BackgroundFill,
@@ -42,4 +43,5 @@ module.exports = {
   InteractionMediaQueries,
   Scrollbar,
   StrokeFull,
+  ColorThemes,
 };

--- a/src/ColorThemes/index.js
+++ b/src/ColorThemes/index.js
@@ -1,0 +1,99 @@
+const plugin = require('tailwindcss/plugin');
+
+module.exports = plugin(function ({ addBase, addUtilities, theme }) {
+  const themes = theme('colorThemes', {});
+  const colors = theme('colors', {});
+
+  const tokens = colors;
+  const textColors = theme('textColor', {});
+  const bgColors = theme('backgroundColor', {});
+  const borderColors = theme('borderColor', {});
+  const outlineColors = theme('outlineColor', {});
+  const divideColors = theme('divideColor', {});
+  const ringColors = theme('ringColor', {});
+  const ringOffsetColors = theme('ringOffsetColor', {});
+  const underlineColors = theme('underlineColor', {});
+
+  const baseStyles = {
+    ':root': Object.fromEntries(
+      Object.entries(tokens).map(([name, value]) => [`--${name}`, value])
+    ),
+  };
+
+  Object.entries(themes).forEach(([themeName, groups]) => {
+    baseStyles[`.theme-${themeName}`] = getThemeRules(groups);
+  });
+
+  const utilities = {
+    ...buildUtilities('text', textColors, 'color', 'text'),
+    ...buildUtilities('bg', bgColors, 'background-color', 'background'),
+    ...buildUtilities('border', borderColors, 'border-color', 'border'),
+    ...buildUtilities('outline', outlineColors, 'outline-color', 'border'),
+    ...buildUtilities('divide', divideColors, '--tw-divide-color', 'border'),
+    ...buildUtilities('ring', ringColors, '--tw-ring-color', 'ring'),
+    ...buildUtilities(
+      'ring-offset',
+      ringOffsetColors,
+      '--tw-ring-offset-color',
+      'border'
+    ),
+    ...buildUtilities(
+      'underline',
+      underlineColors,
+      'text-decoration-color',
+      'text'
+    ),
+  };
+
+  addBase(baseStyles);
+  addUtilities(
+    Object.fromEntries(
+      Object.entries(utilities).map(([selector, styles]) => [
+        `[class*="theme-"] ${selector}`,
+        styles,
+      ])
+    )
+  );
+
+  function buildUtilities(prefix, values, cssProperty, variableGroup) {
+    return Object.fromEntries(
+      Object.entries(values).map(([name, fallback]) => [
+        `.${prefix}-${name}`,
+        {
+          [cssProperty]: `var(--${variableGroup}-${name}, ${resolveColor(fallback)})`,
+        },
+      ])
+    );
+  }
+
+  function getThemeRules(groups) {
+    const rules = {};
+
+    Object.entries(groups).forEach(([usage, values]) => {
+      Object.entries(values).forEach(([name, color]) => {
+        rules[`--${usage}-${name}`] = resolveColor(color);
+      });
+    });
+
+    return rules;
+  }
+
+  function resolveColor(color) {
+    if (typeof color !== 'string') return color;
+
+    // already a CSS value
+    if (
+      color.startsWith('var(') ||
+      color.startsWith('#') ||
+      color.startsWith('rgb') ||
+      color.startsWith('hsl') ||
+      color === 'transparent' ||
+      color === 'currentColor'
+    ) {
+      return color;
+    }
+
+    // treat everything else as a token reference
+    return `var(--${color})`;
+  }
+});

--- a/src/ColorThemes/index.js
+++ b/src/ColorThemes/index.js
@@ -9,7 +9,6 @@ module.exports = plugin(function ({ addBase, addUtilities, theme }) {
   const bgColors = theme('backgroundColor', {});
   const borderColors = theme('borderColor', {});
   const outlineColors = theme('outlineColor', {});
-  const divideColors = theme('divideColor', {});
   const ringColors = theme('ringColor', {});
   const ringOffsetColors = theme('ringOffsetColor', {});
   const underlineColors = theme('underlineColor', {});
@@ -20,6 +19,18 @@ module.exports = plugin(function ({ addBase, addUtilities, theme }) {
     ),
   };
 
+  const defaultThemeGroups = {
+    text: textColors,
+    background: bgColors,
+    border: borderColors,
+    outline: outlineColors,
+    ring: ringColors,
+    'ring-offset': ringOffsetColors,
+    underline: underlineColors,
+  };
+
+  baseStyles['.theme-reset'] = getThemeRules(defaultThemeGroups);
+
   Object.entries(themes).forEach(([themeName, groups]) => {
     baseStyles[`.theme-${themeName}`] = getThemeRules(groups);
   });
@@ -28,20 +39,19 @@ module.exports = plugin(function ({ addBase, addUtilities, theme }) {
     ...buildUtilities('text', textColors, 'color', 'text'),
     ...buildUtilities('bg', bgColors, 'background-color', 'background'),
     ...buildUtilities('border', borderColors, 'border-color', 'border'),
-    ...buildUtilities('outline', outlineColors, 'outline-color', 'border'),
-    ...buildUtilities('divide', divideColors, '--tw-divide-color', 'border'),
+    ...buildUtilities('outline', outlineColors, 'outline-color', 'outline'),
     ...buildUtilities('ring', ringColors, '--tw-ring-color', 'ring'),
     ...buildUtilities(
       'ring-offset',
       ringOffsetColors,
       '--tw-ring-offset-color',
-      'border'
+      'ring-offset'
     ),
     ...buildUtilities(
       'underline',
       underlineColors,
       'text-decoration-color',
-      'text'
+      'underline'
     ),
   };
 


### PR DESCRIPTION
### Summary

Introduces the new **ColorThemes** plugin for Tailwind, enabling token-based theming via CSS variables, along with supporting documentation.

---

### Details

- Adds `ColorThemes` plugin
  - Maps semantic color keys to CSS custom properties
  - Generates theme classes (`.theme-*`) to override values at runtime
  - Provides utility fallbacks to ensure default token values
  - Includes `.theme-reset` to revert to base colors within nested themes

- Adds documentation covering:
  - Setup and configuration
  - How the theming system works
  - Minimal example and demo
  - Supported properties and usage guidelines

---

### Notes

- No breaking changes
- Designed to work alongside existing `ColorTokens` setup